### PR TITLE
Sometimes ItemsControlExtensions throws an ArgumentOutOfRangeException

### DIFF
--- a/GongSolutions.Wpf.DragDrop/Utilities/ItemsControlExtensions.cs
+++ b/GongSolutions.Wpf.DragDrop/Utilities/ItemsControlExtensions.cs
@@ -126,7 +126,9 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
                 foreach (var itemsPresenter in itemsPresenters)
                 {
                     var panel = VisualTreeHelper.GetChild(itemsPresenter, 0);
-                    var itemContainer = VisualTreeHelper.GetChild(panel, 0);
+                    var itemContainer = VisualTreeHelper.GetChildrenCount(panel) > 0
+                                                         ? VisualTreeHelper.GetChild(panel, 0)
+                                                         : null;
 
                     // Ensure that this actually *is* an item container by checking it with
                     // ItemContainerGenerator.


### PR DESCRIPTION
Hi, I'm working on a project that uses this library. Occasionally we run into an `ArgumentOutOfRangeException` when dragging items. The exception is thrown because of a call to `VisualTreeHelper.GetChild(panel, 0)` when `panel` has no children.

I fixed this by just checking there is at least one child before making the call to `GetChild`, but to be honest I don't really understand the code, so I'm unsure if we are simply using the drag and drop library incorrectly, or if this exception is a bug.
