### PR TITLE
Multiple items deselected in ListView and other subclasses of ListBox 

### DIFF
--- a/GongSolutions.Wpf.DragDrop/Utilities/ItemsControlExtensions.cs
+++ b/GongSolutions.Wpf.DragDrop/Utilities/ItemsControlExtensions.cs
@@ -217,7 +217,7 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
             {
                 return ((MultiSelector)itemsControl).SelectedItems;
             }
-            else if (itemsControl.GetType().IsAssignableFrom(typeof(ListBox)))
+            else if (itemsControl is ListBox)
             {
                 var listBox = (ListBox)itemsControl;
 


### PR DESCRIPTION
Hi, first of all, many thanks for taking over this project. Here's a little pull request to fix a small bug: whenever I tried to select multiple items from a ListView and drag them, all the items would be deselected, except the single item I actually started dragging.

This was due to a bug in `ItemsControlExtensions.GetSelectedItems()`:

``` csharp
if (itemsControl.GetType().IsAssignableFrom(typeof(ListBox)))
{
    var listBox = (ListBox)itemsControl;
    ...
```

This is too strict - the IsAssignableFromType() is round the wrong way (can you assign a base class to its subclass? no), so it fails to handle ListView and other subclasses of ListBox. My patch simply changes it to an is operator instead.
