### PR TITLE
Allowed drops to main window where the visual parent would be null.

### DIFF
--- a/GongSolutions.Wpf.DragDrop/DropInfo.cs
+++ b/GongSolutions.Wpf.DragDrop/DropInfo.cs
@@ -43,7 +43,7 @@ namespace GongSolutions.Wpf.DragDrop
       this.VisualTarget = sender as UIElement;
       // if drop target isn't a ItemsControl
       if (!(this.VisualTarget is ItemsControl)) {
-        this.VisualTarget = VisualTreeExtensions.GetVisualAncestor<ItemsControl>(this.VisualTarget);
+        this.VisualTarget = VisualTreeExtensions.GetVisualAncestor<ItemsControl>(this.VisualTarget) ?? this.VisualTarget;
       }
       this.DropPosition = e.GetPosition(this.VisualTarget);
 


### PR DESCRIPTION
In this case the main window itself is the VisualTarget.

Fixes Issue and Closes #75
