### PR TITLE
Handle non-collection targets

### DIFF
--- a/GongSolutions.Wpf.DragDrop/DefaultDropHandler.cs
+++ b/GongSolutions.Wpf.DragDrop/DefaultDropHandler.cs
@@ -57,6 +57,8 @@ namespace GongSolutions.Wpf.DragDrop
         return GetList(dropInfo.TargetCollection) != null;
       } else if (dropInfo.DragInfo.SourceCollection is ItemCollection) {
         return false;
+      } else if (dropInfo.TargetCollection == null) {
+        return false;
       } else {
         if (TestCompatibleTypes(dropInfo.TargetCollection, dropInfo.Data)) {
           return !IsChildOf(dropInfo.VisualTargetItem, dropInfo.DragInfo.VisualSourceItem);


### PR DESCRIPTION
DefaultDropHandler was trying to dereference null when the drop target
wasn't a collection.
