### PR TITLE
added DragAdornerTemplateSelector

### DIFF
--- a/Examples/DefaultsExample/DefaultsExample (NET4).csproj
+++ b/Examples/DefaultsExample/DefaultsExample (NET4).csproj
@@ -90,6 +90,7 @@
     </Compile>
     <Compile Include="CustomListBox.cs" />
     <Compile Include="CustomListBoxItem.cs" />
+    <Compile Include="DemoDataTemplateSelector.cs" />
     <Compile Include="Window%28NET4%29.xaml.cs">
       <DependentUpon>Window%28NET4%29.xaml</DependentUpon>
     </Compile>

--- a/Examples/DefaultsExample/DemoDataTemplateSelector.cs
+++ b/Examples/DefaultsExample/DemoDataTemplateSelector.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Diagnostics;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace DefaultsExample {
+    public class DemoDataTemplateSelector : DataTemplateSelector {
+         public DataTemplate TemplateEven { get; set; }
+         public DataTemplate TemplateOdd { get; set; }
+
+        public override DataTemplate SelectTemplate(object item, DependencyObject container) {
+            var str = (string)item;
+            Debug.Assert(str.StartsWith("Item"));
+            var number = Int32.Parse(str.Substring(4));
+            return (number & 0x01) == 0 ? TemplateEven : TemplateOdd;
+        }
+    }
+}

--- a/Examples/DefaultsExample/Window(NET4).xaml
+++ b/Examples/DefaultsExample/Window(NET4).xaml
@@ -815,5 +815,45 @@
         </ListBox>
       </Grid>
     </TabItem>
+    
+    <TabItem Header="with DataTemplateSelector">
+      <TabItem.Resources>
+        <DataTemplate x:Key="Even">
+          <TextBlock Text="{Binding}" Foreground="Blue"/>
+        </DataTemplate>
+        <DataTemplate x:Key="Odd">
+          <TextBlock Text="{Binding}" Foreground="Green"/>
+        </DataTemplate>
+        <local:DemoDataTemplateSelector 
+          x:Key="DemoDataTemplateSelector"
+          TemplateEven="{StaticResource Even}"
+          TemplateOdd="{StaticResource Odd}"
+          />
+      </TabItem.Resources>
+      <Grid>
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="*" />
+          <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+          <RowDefinition Height="Auto" />
+          <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <TextBlock Grid.ColumnSpan="2">This example uses a DataTemplateSelector for the drag adorner.</TextBlock>
+        <ListBox 
+          Grid.Row="1" Grid.Column="0"
+          SelectionMode="Extended"
+          dd:DragDrop.IsDragSource="True"
+          dd:DragDrop.IsDropTarget="True"
+          dd:DragDrop.DragAdornerTemplateSelector="{StaticResource DemoDataTemplateSelector}"
+          ItemsSource="{Binding Collection1}" />
+        <ListBox 
+          Grid.Row="1" Grid.Column="1"
+          SelectionMode="Extended"
+          dd:DragDrop.IsDragSource="True"
+          dd:DragDrop.IsDropTarget="True"
+          ItemsSource="{Binding Collection3}" />
+      </Grid>
+    </TabItem>
   </TabControl>
 </Window>

--- a/GongSolutions.Wpf.DragDrop/DragDrop.cs
+++ b/GongSolutions.Wpf.DragDrop/DragDrop.cs
@@ -30,6 +30,19 @@ namespace GongSolutions.Wpf.DragDrop
       target.SetValue(DragAdornerTemplateProperty, value);
     }
 
+    public static readonly DependencyProperty DragAdornerTemplateSelectorProperty = DependencyProperty.RegisterAttached(
+      "DragAdornerTemplateSelector", typeof (DataTemplateSelector), typeof (DragDrop), new PropertyMetadata(default(DataTemplateSelector)));
+
+    public static void SetDragAdornerTemplateSelector(DependencyObject element, DataTemplateSelector value) 
+    {
+      element.SetValue(DragAdornerTemplateSelectorProperty, value);
+    }
+
+    public static DataTemplateSelector GetDragAdornerTemplateSelector(DependencyObject element) 
+    {
+      return (DataTemplateSelector) element.GetValue(DragAdornerTemplateSelectorProperty);
+    }
+
     public static readonly DependencyProperty UseDefaultDragAdornerProperty =
       DependencyProperty.RegisterAttached("UseDefaultDragAdorner", typeof(bool), typeof(DragDrop), new PropertyMetadata(false));
 
@@ -349,12 +362,13 @@ namespace GongSolutions.Wpf.DragDrop
     private static void CreateDragAdorner()
     {
       var template = GetDragAdornerTemplate(m_DragInfo.VisualSource);
+      var templateSelector = GetDragAdornerTemplateSelector(m_DragInfo.VisualSource);
 
       UIElement adornment = null;
 
       var useDefaultDragAdorner = GetUseDefaultDragAdorner(m_DragInfo.VisualSource);
 
-      if (template == null && useDefaultDragAdorner) {
+      if (template == null && templateSelector == null && useDefaultDragAdorner) {
         template = new DataTemplate();
 
         var factory = new FrameworkElementFactory(typeof(Image));
@@ -372,12 +386,13 @@ namespace GongSolutions.Wpf.DragDrop
         template.VisualTree = factory;
       }
 
-      if (template != null) {
+      if (template != null || templateSelector != null) {
         if (m_DragInfo.Data is IEnumerable && !(m_DragInfo.Data is string)) {
           if (((IEnumerable)m_DragInfo.Data).Cast<object>().Count() <= 10) {
             var itemsControl = new ItemsControl();
             itemsControl.ItemsSource = (IEnumerable)m_DragInfo.Data;
             itemsControl.ItemTemplate = template;
+            itemsControl.ItemTemplateSelector = templateSelector;
 
             // The ItemsControl doesn't display unless we create a border to contain it.
             // Not quite sure why this is...
@@ -389,6 +404,7 @@ namespace GongSolutions.Wpf.DragDrop
           var contentPresenter = new ContentPresenter();
           contentPresenter.Content = m_DragInfo.Data;
           contentPresenter.ContentTemplate = template;
+          contentPresenter.ContentTemplateSelector = templateSelector;
           adornment = contentPresenter;
         }
       }


### PR DESCRIPTION
In my application there are different types of objects that might be dragged, thus I can not use a fixed `DragAdornerTemplate`. Therefore I added a new property `DragAdornerTemplateSelector` of type `DataTemplateSelector`.

I added an additional tab to the demo application: If you drag items on that page from the left to the right, even numbers are blue and odd numbers are green.

A new drop on NuGet would be appreciated :blush: 
