### PR TITLE
Support for DragDropContext #89

### DIFF
--- a/Examples/NorthwindExample/Views/EmployeesTabView(NET4).xaml
+++ b/Examples/NorthwindExample/Views/EmployeesTabView(NET4).xaml
@@ -37,6 +37,7 @@
               dd:DragDrop.IsDropTarget="True"
               dd:DragDrop.DropHandler="{Binding}"
               dd:DragDrop.DragAdornerTemplate="{x:Null}"
+              dd:DragDrop.DragDropContext="Employees"
               dd:DragDrop.EffectNoneAdornerTemplate="{x:Null}">
       <DataGrid.Columns>
         <DataGridTextColumn Header="First Name"
@@ -54,6 +55,8 @@
              dd:DragDrop.IsDragSource="True"
              dd:DragDrop.IsDropTarget="True"
              dd:DragDrop.DropHandler="{Binding}"
-             dd:DragDrop.DragAdornerTemplate="{x:Null}" />
+             dd:DragDrop.DragAdornerTemplate="{x:Null}"  
+             dd:DragDrop.DragDropContext="EmployeesNotDroppableFromOther"
+             />
   </Grid>
 </UserControl>

--- a/GongSolutions.Wpf.DragDrop/DefaultDropHandler.cs
+++ b/GongSolutions.Wpf.DragDrop/DefaultDropHandler.cs
@@ -53,6 +53,16 @@ namespace GongSolutions.Wpf.DragDrop
         return false;
       }
 
+      if (!String.IsNullOrEmpty((string)dropInfo.DragInfo.VisualSource.GetValue(DragDrop.DragDropContextProperty)))
+      {
+          //Source element has a drag context constraint, we need to check the target property matches.
+          var sourceContext = (string)dropInfo.DragInfo.VisualSource.GetValue(DragDrop.DragDropContextProperty);
+          var targetContext = (string)dropInfo.VisualTarget.GetValue(DragDrop.DragDropContextProperty);
+
+          if (!string.Equals(sourceContext, targetContext))
+              return false;
+      }
+
       if (dropInfo.DragInfo.SourceCollection == dropInfo.TargetCollection) {
         return GetList(dropInfo.TargetCollection) != null;
       } else if (dropInfo.DragInfo.SourceCollection is ItemCollection) {

--- a/GongSolutions.Wpf.DragDrop/DragDrop.cs
+++ b/GongSolutions.Wpf.DragDrop/DragDrop.cs
@@ -228,6 +228,19 @@ namespace GongSolutions.Wpf.DragDrop
       target.SetValue(IsDropTargetProperty, value);
     }
 
+    public static readonly DependencyProperty DragDropContextProperty = 
+        DependencyProperty.RegisterAttached("DragDropContext", typeof(string), typeof(DragDrop), new UIPropertyMetadata(string.Empty));
+
+    public static string GetDragDropContext(UIElement target)
+    {
+        return (string)target.GetValue(DragDropContextProperty);
+    }
+
+    public static void SetDragDropContext(UIElement target, string value)
+    {
+        target.SetValue(DragDropContextProperty, value);
+    }
+
     public static readonly DependencyProperty DragHandlerProperty =
       DependencyProperty.RegisterAttached("DragHandler", typeof(IDragSource), typeof(DragDrop));
 
@@ -814,6 +827,17 @@ namespace GongSolutions.Wpf.DragDrop
 
       e.Effects = dropInfo.Effects;
       e.Handled = !dropInfo.NotHandled;
+
+      if (!string.IsNullOrEmpty((string)dropInfo.DragInfo.VisualSource.GetValue(DragDrop.DragDropContextProperty)))
+      {
+          var sourceContext = (string)dropInfo.DragInfo.VisualSource.GetValue(DragDrop.DragDropContextProperty);
+          var targetContext = (string)dropInfo.VisualTarget.GetValue(DragDrop.DragDropContextProperty);
+
+          if (!string.IsNullOrEmpty(targetContext) && !string.Equals(sourceContext, targetContext))
+          {
+              e.Effects = DragDropEffects.None;
+          }
+      }
 
       Scroll((DependencyObject)dropInfo.VisualTarget, e);
     }


### PR DESCRIPTION
Added optional DragDropContext dependency property for declarative of
DragDrop operations. Useful when users may have 2+ drag targets/sources
where source and destination need to be constrained.

Closes #89 