### PR TITLE
Added DragDirectlySelectedOnly

### DIFF
--- a/Examples/DefaultsExample/Window(NET4).xaml
+++ b/Examples/DefaultsExample/Window(NET4).xaml
@@ -546,6 +546,7 @@
     <TabItem Header="ListBox with Groups">
       <ListBox ItemsSource="{Binding Source={StaticResource GroupedCollectionViewSource}}"
                DisplayMemberPath="Caption"
+               dd:DragDrop.DragDirectlySelectedOnly="True"
                dd:DragDrop.IsDragSource="True"
                dd:DragDrop.IsDropTarget="True"
                dd:DragDrop.DropHandler="{Binding}">

--- a/GongSolutions.Wpf.DragDrop/DragDrop.cs
+++ b/GongSolutions.Wpf.DragDrop/DragDrop.cs
@@ -267,6 +267,19 @@ namespace GongSolutions.Wpf.DragDrop
       target.SetValue(DragSourceIgnoreProperty, value);
     }
 
+    public static readonly DependencyProperty DragDirectlySelectedOnlyProperty =
+      DependencyProperty.RegisterAttached("DragDirectlySelectedOnly", typeof(bool), typeof(DragDrop), new PropertyMetadata(false));
+      
+    public static bool GetDragDirectlySelectedOnly(DependencyObject obj)
+    {
+      return (bool)obj.GetValue(DragDirectlySelectedOnlyProperty);
+    }
+
+    public static void SetDragDirectlySelectedOnly(DependencyObject obj, bool value)
+    {
+      obj.SetValue(DragDirectlySelectedOnlyProperty, value);
+    }
+
     /// <summary>
     /// DragMouseAnchorPoint defines the horizontal and vertical proportion at which the pointer will anchor on the DragAdorner.
     /// </summary>

--- a/GongSolutions.Wpf.DragDrop/DragInfo.cs
+++ b/GongSolutions.Wpf.DragDrop/DragInfo.cs
@@ -52,8 +52,12 @@ namespace GongSolutions.Wpf.DragDrop
         if (sourceItem != null) {
           item = itemsControl.GetItemContainer(sourceItem);
         }
+          
         if (item == null) {
-          item = itemsControl.GetItemContainerAt(e.GetPosition(itemsControl), itemsControl.GetItemsPanelOrientation());
+          if (DragDrop.GetDragDirectlySelectedOnly(VisualSource))
+            item = itemsControl.GetItemContainerAt(e.GetPosition(itemsControl));
+          else
+            item = itemsControl.GetItemContainerAt(e.GetPosition(itemsControl), itemsControl.GetItemsPanelOrientation());
         }
 
         if (item != null) {


### PR DESCRIPTION
Don't search for closest item. This allows to start selection when drag starts on empty space inside ListBox. Can be used with [that behavior](http://www.codeproject.com/Articles/209560/ListBox-drag-selection) after some changes in OnPreviewMouseLeftButtonDown.