### PR TITLE
Support drag after last item in grouped list

### DIFF
--- a/GongSolutions.Wpf.DragDrop/DropTargetInsertionAdorner.cs
+++ b/GongSolutions.Wpf.DragDrop/DropTargetInsertionAdorner.cs
@@ -38,7 +38,7 @@ namespace GongSolutions.Wpf.DragDrop
         if (targetGroup != null && targetGroup.IsBottomLevel && this.DropInfo.InsertPosition.HasFlag(RelativeInsertPosition.AfterTargetItem)) {
           var indexOf = targetGroup.Items.IndexOf(this.DropInfo.TargetItem);
           lastItemInGroup = indexOf == targetGroup.ItemCount - 1;
-          if (lastItemInGroup) {
+          if (lastItemInGroup && this.DropInfo.InsertIndex != itemParent.Items.Count) {
             index--;
           }
         }

--- a/GongSolutions.Wpf.DragDrop/Utilities/ItemsControlExtensions.cs
+++ b/GongSolutions.Wpf.DragDrop/Utilities/ItemsControlExtensions.cs
@@ -25,6 +25,26 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
       if (element != null) {
         var groupItem = element.GetVisualAncestor<GroupItem>();
 
+        // drag after last item - get group of it
+        if (itemsControl.Items.Groups != null && groupItem == null && itemsControl.Items.Count > 0)
+        {
+          var lastItem = itemsControl.ItemContainerGenerator.ContainerFromItem(itemsControl.Items.GetItemAt(itemsControl.Items.Count - 1)) as FrameworkElement;
+          if (lastItem != null)
+          {
+            var itemEndpoint = lastItem.PointToScreen(new Point(lastItem.ActualWidth, lastItem.ActualHeight));
+            var positionToScreen = itemsControl.PointToScreen(position);
+            switch (itemsControl.GetItemsPanelOrientation())
+            {
+              case Orientation.Horizontal:
+                // assume LeftToRight
+                groupItem = itemEndpoint.X <= positionToScreen.X ? lastItem.GetVisualAncestor<GroupItem>() : null;
+                break;
+              case Orientation.Vertical:
+                groupItem = itemEndpoint.Y <= positionToScreen.Y ? lastItem.GetVisualAncestor<GroupItem>() : null;
+                break;
+            }
+          }
+        }
         if (groupItem != null) {
           return groupItem.Content as CollectionViewGroup;
         }


### PR DESCRIPTION
If we drag after last item in grouped list, assume to move it at the end.