### PR TITLE
Fix an issue when the itempresenter contains more ContentControls

### DIFF
--- a/GongSolutions.Wpf.DragDrop/Utilities/VisualTreeExtensions.cs
+++ b/GongSolutions.Wpf.DragDrop/Utilities/VisualTreeExtensions.cs
@@ -71,7 +71,8 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
         if (item == itemsControl) {
           return lastFoundItemByType;
         }
-        if (item.GetType() == type || item.GetType().IsSubclassOf(type)) {
+        if ((item.GetType() == type || item.GetType().IsSubclassOf(type))
+            && (itemsControl == null || itemsControl.ItemContainerGenerator.IndexFromContainer(item) >= 0)) {
           lastFoundItemByType = item;
         }
         item = VisualTreeHelper.GetParent(item);


### PR DESCRIPTION
When using a scroll viewer on a custom control the given ContentPresenter isn't correctly returned by the `GetVisualAncestor()` method. Because there are 2 (the scrollcontentpresenter and the own contentpresenter). Therefore the Collection can't be determinate, and a null reference exception will be thrown.

Example Control
```
    <Style TargetType="{x:Type local:CustomControl1}">
        <Setter Property="Template">
            <Setter.Value>
                <ControlTemplate TargetType="{x:Type local:CustomControl1}">
                    <Border Background="Red">
                        <ScrollViewer>
                            <ItemsPresenter />
                        </ScrollViewer>
                    </Border>
                </ControlTemplate>
            </Setter.Value>
        </Setter>
    </Style>
``` 
and the class file
```

public class CustomControl1 : ItemsControl
    {

        public IDragSource DragHandler
        {
            get { return (IDragSource)GetValue(GongSolutions.Wpf.DragDrop.DragDrop.DragHandlerProperty); }
            set { SetValue(GongSolutions.Wpf.DragDrop.DragDrop.DragHandlerProperty, value); }
        }

        public IDropTarget DropHandler
        {
            get { return (IDropTarget)GetValue(GongSolutions.Wpf.DragDrop.DragDrop.DropHandlerProperty); }
            set { SetValue(GongSolutions.Wpf.DragDrop.DragDrop.DropHandlerProperty, value); }
        }

        static CustomControl1()
        {
            DefaultStyleKeyProperty.OverrideMetadata(typeof(CustomControl1), new FrameworkPropertyMetadata(typeof(CustomControl1)));
        }

        public CustomControl1()
        {
            SetValue(GongSolutions.Wpf.DragDrop.DragDrop.IsDragSourceProperty, true);
            DragHandler = new DragSource();
            SetValue(GongSolutions.Wpf.DragDrop.DragDrop.IsDropTargetProperty, true);
            DropHandler = new MoveDropTarget();
        }

    }
```
And in the MainWindow.xaml

```
<l:CustomControl1 ItemsSource="{Binding MyProperty}"  Grid.Column="0">
                    <l:CustomControl1.ItemTemplate>
                        <DataTemplate>
                            <Border Background="Yellow" Margin="4">
                                <TextBlock Text="{Binding Id}" />
                            </Border>
                        </DataTemplate>
                    </l:CustomControl1.ItemTemplate>
                </l:CustomControl1>
```