### PR TITLE
Default drop handler changes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,9 +7,14 @@ end_of_line = CRLF
 ; 4-column tab indentation
 [*.cs]
 indent_style = space
-indent_size = 4
+indent_size = 2
 
 ; 4-column tab indentation
 [*.xaml]
 indent_style = space
-indent_size = 4
+indent_size = 2
+
+; 4-column tab indentation
+[*.xml]
+indent_style = space
+indent_size = 2

--- a/Examples/DefaultsExample/Data.cs
+++ b/Examples/DefaultsExample/Data.cs
@@ -1,16 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
 using System.Collections.ObjectModel;
 using System.Windows;
 using GongSolutions.Wpf.DragDrop;
 using System.ComponentModel;
-using System.Windows.Data;
 using System.Windows.Controls;
-using System.Collections;
-using GongSolutions.Wpf.DragDrop.Utilities;
 using DragDrop = GongSolutions.Wpf.DragDrop.DragDrop;
 
 namespace DefaultsExample
@@ -67,6 +60,8 @@ namespace DefaultsExample
       this.Collection4 = new ObservableCollection<string>();
       this.CustomCollection1 = new ObservableCollection<CustomDataModel>();
       this.CustomCollection2 = new ObservableCollection<CustomDataModel>();
+      this.ClonableCollection1 = new ObservableCollection<ClonableDataModel>();
+      this.ClonableCollection2 = new ObservableCollection<ClonableDataModel>();
 
       this.CustomDropHandler = new CustomDropHandlerForIssue85();
       this.CustomDragHandler = new CustomDragHandlerForIssue84();
@@ -74,6 +69,7 @@ namespace DefaultsExample
       for (var n = 0; n < 100; ++n) {
         this.Collection1.Add("Item " + n);
         this.CustomCollection1.Add(new CustomDataModel { Name = "Custom Item " + n });
+        this.ClonableCollection1.Add(new ClonableDataModel("Clonable Item " + n ));
       }
 
       for (var n = 0; n < 4; ++n) {
@@ -108,6 +104,8 @@ namespace DefaultsExample
     public ObservableCollection<string> Collection4 { get; private set; }
     public ObservableCollection<CustomDataModel> CustomCollection1 { get; private set; }
     public ObservableCollection<CustomDataModel> CustomCollection2 { get; private set; }
+    public ObservableCollection<ClonableDataModel> ClonableCollection1 { get; private set; }
+    public ObservableCollection<ClonableDataModel> ClonableCollection2 { get; private set; }
     public ObservableCollection<GroupedItem> GroupedCollection { get; private set; }
     public ObservableCollection<TreeNode> TreeCollection { get; private set; }
 
@@ -160,6 +158,41 @@ namespace DefaultsExample
       if (dropInfo.DragInfo.Data is CustomDataModel) {
         dropInfo.NotHandled = true; // now the DefaultDropHandler should work
       }
+    }
+  }
+
+  internal class ClonableDataModel : ICloneable, INotifyPropertyChanged
+  {
+    public ClonableDataModel(string name)
+    {
+      Name = name;
+    }
+
+    private string _name;
+    public string Name
+    {
+      get { return this._name; }
+      set
+      {
+        if (this._name != value)
+        {
+          this._name = value;
+          this.OnPropertyChanged("Name");
+        }
+      }
+    }
+
+    public object Clone()
+    {
+      return new ClonableDataModel(Name + ", now cloned");
+    }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+      var handler = PropertyChanged;
+      if (handler != null) { handler(this, new PropertyChangedEventArgs(propertyName)); }
     }
   }
 

--- a/Examples/DefaultsExample/Window(NET4).xaml
+++ b/Examples/DefaultsExample/Window(NET4).xaml
@@ -464,6 +464,54 @@
       </Grid>
     </TabItem>
 
+    <TabItem Header="Cloning">
+      <Grid>
+        <Grid.Resources>
+          <DataTemplate x:Key="CloningTemplate"
+                        DataType="{x:Type local:ClonableDataModel}">
+            <Grid>
+              <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+              </Grid.ColumnDefinitions>
+              <TextBlock Text="::" FontWeight="Bold" Grid.Column="0" />
+              <TextBox Grid.Column="1"
+                       Text="{Binding Name}"
+                       Margin="5 1 5 1" />
+            </Grid>
+          </DataTemplate>
+          <DataTemplate x:Key="CloningAdornerTemplate"
+                        DataType="{x:Type local:ClonableDataModel}">
+            <TextBlock Text="{Binding Name}" />
+          </DataTemplate>
+        </Grid.Resources>
+
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition />
+          <ColumnDefinition />
+        </Grid.ColumnDefinitions>
+
+        <ListBox Grid.Column="0"
+                 ItemsSource="{Binding ClonableCollection1}"
+                 SelectionMode="Extended"
+                 HorizontalContentAlignment="Stretch"
+                 ItemTemplate="{StaticResource CloningTemplate}"
+                 dd:DragDrop.DragAdornerTemplate="{StaticResource CloningAdornerTemplate}"
+                 dd:DragDrop.UseDefaultDragAdorner="True"
+                 dd:DragDrop.IsDragSource="True"
+                 dd:DragDrop.IsDropTarget="True" />
+        <ListBox Grid.Column="1"
+                 ItemsSource="{Binding ClonableCollection2}"
+                 SelectionMode="Extended"
+                 HorizontalContentAlignment="Stretch"
+                 ItemTemplate="{StaticResource CloningTemplate}"
+                 dd:DragDrop.DragAdornerTemplate="{StaticResource CloningAdornerTemplate}"
+                 dd:DragDrop.UseDefaultDragAdorner="True"
+                 dd:DragDrop.IsDragSource="True"
+                 dd:DragDrop.IsDropTarget="True" />
+      </Grid>
+    </TabItem>
+
     <TabItem Header="Bound ListViews">
       <Grid>
         <Grid.ColumnDefinitions>

--- a/GongSolutions.Wpf.DragDrop (NET4).sln.GhostDoc.xml
+++ b/GongSolutions.Wpf.DragDrop (NET4).sln.GhostDoc.xml
@@ -1,6 +1,0 @@
-<GhostDoc>
-  <IgnoreFilePatterns>
-    <IgnoreFilePattern>*.min.js</IgnoreFilePattern>
-    <IgnoreFilePattern>jquery*.js</IgnoreFilePattern>
-  </IgnoreFilePatterns>
-</GhostDoc>

--- a/GongSolutions.Wpf.DragDrop/DefaultDropHandler.cs
+++ b/GongSolutions.Wpf.DragDrop/DefaultDropHandler.cs
@@ -26,6 +26,7 @@ namespace GongSolutions.Wpf.DragDrop
     public virtual void DragOver(IDropInfo dropInfo)
     {
       if (CanAcceptData(dropInfo)) {
+        // when source is the same as the target set the move effect otherwise set the copy effect
         dropInfo.Effects = dropInfo.DragInfo.VisualSource == dropInfo.VisualTarget ? DragDropEffects.Move : DragDropEffects.Copy;
         dropInfo.DropTargetAdorner = DropTargetAdorners.Insert;
       }
@@ -45,6 +46,7 @@ namespace GongSolutions.Wpf.DragDrop
       var destinationList = dropInfo.TargetCollection.TryGetList();
       var data = ExtractData(dropInfo.Data);
 
+      // when source is the same as the target remove the data from source and fix the insertion index
       if (dropInfo.DragInfo.VisualSource == dropInfo.VisualTarget) {
         var sourceList = dropInfo.DragInfo.SourceCollection.TryGetList();
 
@@ -53,7 +55,7 @@ namespace GongSolutions.Wpf.DragDrop
 
           if (index != -1) {
             sourceList.RemoveAt(index);
-
+            // so, is the source list the destination list too ?
             if (Equals(sourceList, destinationList) && index < insertIndex) {
               --insertIndex;
             }
@@ -61,6 +63,7 @@ namespace GongSolutions.Wpf.DragDrop
         }
       }
 
+      // check for cloning
       var cloneData = dropInfo.Effects.HasFlag(DragDropEffects.Copy) || dropInfo.Effects.HasFlag(DragDropEffects.Link);
       foreach (var o in data) {
         var obj2Insert = o;

--- a/GongSolutions.Wpf.DragDrop/DefaultDropHandler.cs
+++ b/GongSolutions.Wpf.DragDrop/DefaultDropHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -8,24 +9,44 @@ using System.Windows.Controls;
 
 namespace GongSolutions.Wpf.DragDrop
 {
+  /// <summary>
+  /// A default insertion drop handler for the most common usages
+  /// </summary>
   public class DefaultDropHandler : IDropTarget
   {
+    /// <summary>
+    /// Updates the current drag state.
+    /// </summary>
+    /// <param name="dropInfo">Information about the drag.</param>
+    /// <remarks>
+    /// To allow a drop at the current drag position, the <see cref="DropInfo.Effects" /> property on
+    /// <paramref name="dropInfo" /> should be set to a value other than <see cref="DragDropEffects.None" />
+    /// and <see cref="DropInfo.Data" /> should be set to a non-null value.
+    /// </remarks>
     public virtual void DragOver(IDropInfo dropInfo)
     {
       if (CanAcceptData(dropInfo)) {
-        dropInfo.Effects = DragDropEffects.Copy;
+        dropInfo.Effects = dropInfo.DragInfo.VisualSource == dropInfo.VisualTarget ? DragDropEffects.Move : DragDropEffects.Copy;
         dropInfo.DropTargetAdorner = DropTargetAdorners.Insert;
       }
     }
 
+    /// <summary>
+    /// Performs a drop.
+    /// </summary>
+    /// <param name="dropInfo">Information about the drop.</param>
     public virtual void Drop(IDropInfo dropInfo)
     {
+      if (dropInfo == null || dropInfo.DragInfo == null) {
+        return;
+      }
+      
       var insertIndex = dropInfo.InsertIndex != dropInfo.UnfilteredInsertIndex ? dropInfo.UnfilteredInsertIndex : dropInfo.InsertIndex;
-      var destinationList = dropInfo.TargetCollection.ToList();
+      var destinationList = dropInfo.TargetCollection.TryGetList();
       var data = ExtractData(dropInfo.Data);
 
       if (dropInfo.DragInfo.VisualSource == dropInfo.VisualTarget) {
-        var sourceList = dropInfo.DragInfo.SourceCollection.ToList();
+        var sourceList = dropInfo.DragInfo.SourceCollection.TryGetList();
 
         foreach (var o in data) {
           var index = sourceList.IndexOf(o);
@@ -40,24 +61,35 @@ namespace GongSolutions.Wpf.DragDrop
         }
       }
 
+      var cloneData = dropInfo.Effects.HasFlag(DragDropEffects.Copy) || dropInfo.Effects.HasFlag(DragDropEffects.Link);
       foreach (var o in data) {
-        destinationList.Insert(insertIndex++, o);
+        var obj2Insert = o;
+        if (cloneData) {
+          var cloneable = o as ICloneable;
+          if (cloneable != null) {
+            obj2Insert = cloneable.Clone();
+          }
+        }
+        destinationList.Insert(insertIndex++, obj2Insert);
       }
     }
 
+    /// <summary>
+    /// Test the specified drop information for the right data.
+    /// </summary>
+    /// <param name="dropInfo">The drop information.</param>
     public static bool CanAcceptData(IDropInfo dropInfo)
     {
       if (dropInfo == null || dropInfo.DragInfo == null) {
         return false;
       }
 
-      if (!dropInfo.IsSameDragDropContextAsSource)
-      {
-          return false;
+      if (!dropInfo.IsSameDragDropContextAsSource) {
+        return false;
       }
 
       if (dropInfo.DragInfo.SourceCollection == dropInfo.TargetCollection) {
-        return dropInfo.TargetCollection.ToList() != null;
+        return dropInfo.TargetCollection.TryGetList() != null;
       } else if (dropInfo.DragInfo.SourceCollection is ItemCollection) {
         return false;
       } else if (dropInfo.TargetCollection == null) {

--- a/GongSolutions.Wpf.DragDrop/DragDrop.cs
+++ b/GongSolutions.Wpf.DragDrop/DragDrop.cs
@@ -896,6 +896,7 @@ namespace GongSolutions.Wpf.DragDrop
       EffectAdorner = null;
       DropTargetAdorner = null;
 
+      dropHandler.DragOver(dropInfo);
       dropHandler.Drop(dropInfo);
       dragHandler.Dropped(dropInfo);
 

--- a/GongSolutions.Wpf.DragDrop/DropInfo.cs
+++ b/GongSolutions.Wpf.DragDrop/DropInfo.cs
@@ -187,7 +187,7 @@ namespace GongSolutions.Wpf.DragDrop
       {
         var insertIndex = this.InsertIndex;
         if (itemParent != null) {
-          var itemSourceAsList = itemParent.ItemsSource.ToList();
+          var itemSourceAsList = itemParent.ItemsSource.TryGetList();
           if (itemSourceAsList != null && itemParent.Items != null && itemParent.Items.Count != itemSourceAsList.Count) {
             if (insertIndex >= 0 && insertIndex < itemParent.Items.Count) {
               var indexOf = itemSourceAsList.IndexOf(itemParent.Items[insertIndex]);

--- a/GongSolutions.Wpf.DragDrop/Utilities/TypeUtilities.cs
+++ b/GongSolutions.Wpf.DragDrop/Utilities/TypeUtilities.cs
@@ -82,12 +82,13 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
     /// </summary>
     /// <param name="enumerable">The enumerable.</param>
     /// <returns>Returns a list.</returns>
-    public static IList ToList(this IEnumerable enumerable)
+    public static IList TryGetList(this IEnumerable enumerable)
     {
       if (enumerable is ICollectionView) {
         return ((ICollectionView)enumerable).SourceCollection as IList;
       } else {
-        return enumerable as IList;
+        var list = enumerable as IList;
+        return list ?? (enumerable != null ? enumerable.OfType<object>().ToList() : null);
       }
     }
   }


### PR DESCRIPTION
- call DragOver in drop event too
- ICloneable support for copy or link effect
- rename `ToList` -> `TryGetList` and check for `IList`

Closes  #106 Dragging between controls creates a shallow copy