### PR TITLE
fix for shift-click multiselection

### DIFF
--- a/GongSolutions.Wpf.DragDrop/DragDrop.cs
+++ b/GongSolutions.Wpf.DragDrop/DragDrop.cs
@@ -716,9 +716,8 @@ namespace GongSolutions.Wpf.DragDrop
       var itemsControl = sender as ItemsControl;
 
       if (m_DragInfo.VisualSourceItem != null && itemsControl != null && itemsControl.CanSelectMultipleItems()) {
-        var selectedItems = itemsControl.GetSelectedItems().Cast<object>();
-
-        if (selectedItems.Count() > 1 && selectedItems.Contains(m_DragInfo.SourceItem)) {
+        var selectedItems = itemsControl.GetSelectedItems().OfType<object>().ToList();
+        if (selectedItems.Count() > 1 && selectedItems.Contains(m_DragInfo.SourceItem) && (Keyboard.Modifiers & ModifierKeys.Shift) == 0) {
           m_ClickSupressItem = m_DragInfo.SourceItem;
           e.Handled = true;
         }
@@ -734,7 +733,7 @@ namespace GongSolutions.Wpf.DragDrop
       if (itemsControl != null && m_DragInfo != null && m_ClickSupressItem == m_DragInfo.SourceItem) {
         if ((Keyboard.Modifiers & ModifierKeys.Control) != 0) {
           itemsControl.SetItemSelected(m_DragInfo.SourceItem, false);
-        } else {
+        } else if ((Keyboard.Modifiers & ModifierKeys.Shift) == 0) {
           itemsControl.SetSelectedItem(m_DragInfo.SourceItem);
         }
       }

--- a/GongSolutions.Wpf.DragDrop/Utilities/ItemsControlExtensions.cs
+++ b/GongSolutions.Wpf.DragDrop/Utilities/ItemsControlExtensions.cs
@@ -230,8 +230,15 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
         ((MultiSelector)itemsControl).SelectedItem = null;
         ((MultiSelector)itemsControl).SelectedItem = item;
       } else if (itemsControl is ListBox) {
-        ((ListBox)itemsControl).SelectedItem = null;
-        ((ListBox)itemsControl).SelectedItem = item;
+        var selectionMode = ((ListBox)itemsControl).SelectionMode;
+        try {
+          // change SelectionMode for UpdateAnchorAndActionItem
+          ((ListBox)itemsControl).SelectionMode = SelectionMode.Single;
+          ((ListBox)itemsControl).SelectedItem = null;
+          ((ListBox)itemsControl).SelectedItem = item;
+        } finally {
+          ((ListBox)itemsControl).SelectionMode = selectionMode;
+        }
       } else if (itemsControl is TreeView) {
         ((TreeView)itemsControl).SetValue(TreeView.SelectedItemProperty, null);
         ((TreeView)itemsControl).SetValue(TreeView.SelectedItemProperty, item);
@@ -239,6 +246,20 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
         ((Selector)itemsControl).SelectedItem = null;
         ((Selector)itemsControl).SelectedItem = item;
       }
+    }
+
+    public static object GetSelectedItem(this ItemsControl itemsControl)
+    {
+      if (itemsControl is MultiSelector) {
+        return ((MultiSelector)itemsControl).SelectedItem;
+      } else if (itemsControl is ListBox) {
+        return ((ListBox)itemsControl).SelectedItem;
+      } else if (itemsControl is TreeView) {
+        return ((TreeView)itemsControl).GetValue(TreeView.SelectedItemProperty);
+      } else if (itemsControl is Selector) {
+        return ((Selector)itemsControl).SelectedItem;
+      }
+      return null;
     }
 
     public static IEnumerable GetSelectedItems(this ItemsControl itemsControl)


### PR DESCRIPTION
Closes #127 Shift + Click item of multi-selectable Listbox doesn't work as windows file explorer

![animation 0](https://cloud.githubusercontent.com/assets/658431/7102847/402e4298-e090-11e4-9457-084d7d47ddc0.gif)
