### PR TITLE
Enable drop-target adorners for non-ItemsControl target

### DIFF
--- a/GongSolutions.Wpf.DragDrop/DragDrop.cs
+++ b/GongSolutions.Wpf.DragDrop/DragDrop.cs
@@ -891,7 +891,7 @@ namespace GongSolutions.Wpf.DragDrop
         var adornedElement =
           itemsControl is TabControl
             ? itemsControl.GetVisualDescendent<TabPanel>()
-            : (itemsControl.GetVisualDescendent<ItemsPresenter>() ?? itemsControl.GetVisualDescendent<ScrollContentPresenter>() as UIElement);
+            : (itemsControl.GetVisualDescendent<ItemsPresenter>() ?? itemsControl.GetVisualDescendent<ScrollContentPresenter>() as UIElement) ?? itemsControl;
 
         if (adornedElement != null) {
           if (dropInfo.DropTargetAdorner == null) {

--- a/GongSolutions.Wpf.DragDrop/DropInfo.cs
+++ b/GongSolutions.Wpf.DragDrop/DropInfo.cs
@@ -155,6 +155,8 @@ namespace GongSolutions.Wpf.DragDrop
               this.InsertPosition |= RelativeInsertPosition.TargetItemCenter;
             }
             //System.Diagnostics.Debug.WriteLine("==> DropInfo: InsPos={0}, InsIndex={1}, X={2}, Item={3}", this.InsertPosition, this.InsertIndex, currentXPos, item);
+          } else {
+            this.VisualTargetItem = this.VisualTarget; 
           }
         }
         else


### PR DESCRIPTION
If you have a ListBox with items that represent groups, and those items implement IDropTarget, you want to be able to use the Highlight adorner on them.