### PR TITLE
Allow target adorners on non-ItemsControls

### DIFF
--- a/GongSolutions.Wpf.DragDrop/DragDrop.cs
+++ b/GongSolutions.Wpf.DragDrop/DragDrop.cs
@@ -891,7 +891,7 @@ namespace GongSolutions.Wpf.DragDrop
         var adornedElement =
           itemsControl is TabControl
             ? itemsControl.GetVisualDescendent<TabPanel>()
-            : (itemsControl.GetVisualDescendent<ItemsPresenter>() ?? itemsControl.GetVisualDescendent<ScrollContentPresenter>() as UIElement) ?? itemsControl;
+            : (itemsControl.GetVisualDescendent<ItemsPresenter>() ?? itemsControl.GetVisualDescendent<ScrollContentPresenter>() as UIElement ?? itemsControl);
 
         if (adornedElement != null) {
           if (dropInfo.DropTargetAdorner == null) {

--- a/GongSolutions.Wpf.DragDrop/DragDrop.cs
+++ b/GongSolutions.Wpf.DragDrop/DragDrop.cs
@@ -891,7 +891,7 @@ namespace GongSolutions.Wpf.DragDrop
         var adornedElement =
           itemsControl is TabControl
             ? itemsControl.GetVisualDescendent<TabPanel>()
-            : (itemsControl.GetVisualDescendent<ItemsPresenter>() ?? itemsControl.GetVisualDescendent<ScrollContentPresenter>() as UIElement);
+            : (itemsControl.GetVisualDescendent<ItemsPresenter>() ?? itemsControl.GetVisualDescendent<ScrollContentPresenter>() as UIElement) ?? itemsControl;
 
         if (adornedElement != null) {
           if (dropInfo.DropTargetAdorner == null) {

--- a/GongSolutions.Wpf.DragDrop/DropInfo.cs
+++ b/GongSolutions.Wpf.DragDrop/DropInfo.cs
@@ -155,9 +155,7 @@ namespace GongSolutions.Wpf.DragDrop
               this.InsertPosition |= RelativeInsertPosition.TargetItemCenter;
             }
             //System.Diagnostics.Debug.WriteLine("==> DropInfo: InsPos={0}, InsIndex={1}, X={2}, Item={3}", this.InsertPosition, this.InsertIndex, currentXPos, item);
-          } else {
-            this.VisualTargetItem = this.VisualTarget; 
-          }
+          } 
         }
         else
         {
@@ -165,6 +163,8 @@ namespace GongSolutions.Wpf.DragDrop
           this.InsertIndex = itemsControl.Items.Count;
           //System.Diagnostics.Debug.WriteLine("==> DropInfo: {0}, item=NULL, {1}", this.InsertPosition, this.InsertIndex);
         }
+      } else {
+            this.VisualTargetItem = this.VisualTarget; 
       }
     }
 

--- a/GongSolutions.Wpf.DragDrop/DropInfo.cs
+++ b/GongSolutions.Wpf.DragDrop/DropInfo.cs
@@ -155,6 +155,8 @@ namespace GongSolutions.Wpf.DragDrop
               this.InsertPosition |= RelativeInsertPosition.TargetItemCenter;
             }
             //System.Diagnostics.Debug.WriteLine("==> DropInfo: InsPos={0}, InsIndex={1}, X={2}, Item={3}", this.InsertPosition, this.InsertIndex, currentXPos, item);
+          } else {
+            this.VisualTargetItem = this.VisualTarget; 
           }
         }
         else


### PR DESCRIPTION
Consider a listbox bound to a collection representing groups of items. You want to drag into the list *or* in an *item*. The item implements IDropTarget, and you need it to show HighlightAdorner - but that only works on a valid VisualTargetItem which is only set on ItemsControls. Added code to fallback setting VisualTargetItem = VisualTarget, and checking for target adorner on any target UIElement.