### PR TITLE
Fix IsNotPartOfSender fixes #156

### DIFF
--- a/GongSolutions.Wpf.DragDrop/Utilities/HitTestUtilities.cs
+++ b/GongSolutions.Wpf.DragDrop/Utilities/HitTestUtilities.cs
@@ -100,6 +100,9 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
         if (depObj == null) {
           return false;
         }
+        if (depObj == sender) {
+          return false;
+        }
         var item = VisualTreeHelper.GetParent(depObj.FindVisualTreeRoot());
         //var item = VisualTreeHelper.GetParent(e.OriginalSource as DependencyObject);
 


### PR DESCRIPTION
Method HitTestUtilities.IsNotPartOfSender was not testing whether the sender of the event and the original source were the same object or not.

It now does it, before doing the parent searching.
