### PR TITLE
Make DefaultDragHandler.CanStartDrag virtual

### DIFF
--- a/GongSolutions.Wpf.DragDrop/DefaultDragHandler.cs
+++ b/GongSolutions.Wpf.DragDrop/DefaultDragHandler.cs
@@ -38,7 +38,7 @@ namespace GongSolutions.Wpf.DragDrop
     /// </summary>
     /// <param name="dragInfo">The drag information.</param>
     /// <returns></returns>
-    public bool CanStartDrag(IDragInfo dragInfo)
+    public virtual bool CanStartDrag(IDragInfo dragInfo)
     {
       return true;
     }


### PR DESCRIPTION
Hi! Thank you for the great library!
I want to inherit from `DefaultDragHandler` to ignore `NumericUpDown` from `MahApps` as you did with `TextBox`, `ComboBox`, etc.
As I can see there is no reason to not allow to override `CanStartDrag`.