### PR TITLE
Add check for itemControls having items to methods GetItemContainer and GetItemContainerAt

### DIFF
--- a/GongSolutions.Wpf.DragDrop/Utilities/ItemsControlExtensions.cs
+++ b/GongSolutions.Wpf.DragDrop/Utilities/ItemsControlExtensions.cs
@@ -76,6 +76,9 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
 
     public static UIElement GetItemContainer(this ItemsControl itemsControl, UIElement child)
     {
+      if (!itemsControl.HasItems)
+        return null;
+
       bool isItemContainer;
       var itemType = GetItemContainerType(itemsControl, out isItemContainer);
 
@@ -90,6 +93,9 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
 
     public static UIElement GetItemContainerAt(this ItemsControl itemsControl, Point position)
     {
+      if (!itemsControl.HasItems)
+        return null;
+
       var inputElement = itemsControl.InputHitTest(position);
       var uiElement = inputElement as UIElement;
 
@@ -103,6 +109,9 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
     public static UIElement GetItemContainerAt(this ItemsControl itemsControl, Point position,
                                                Orientation searchDirection)
     {
+      if (!itemsControl.HasItems)
+        return null;
+
       bool isItemContainer;
       var itemContainerType = GetItemContainerType(itemsControl, out isItemContainer);
 


### PR DESCRIPTION
As a first attempt to fix issue #168 I added some checks to `GetItemContainer` and `GetItemContainerAt` in `ItemsControlExtensions`. The idea behind this check is that if we already know that the target collection is empty, there is no real point in searching for a target item. There will definitely be no target item.