### PR TITLE
Hit test DragDrop start fixes

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.cs
@@ -725,7 +725,6 @@ public static IDragSource DefaultDragHandler
           || (e.OriginalSource as UIElement).IsDragSourceIgnored()
           || (sender is TabControl) && !HitTestUtilities.HitTest4Type<TabPanel>(sender, elementPosition)
           || HitTestUtilities.HitTest4Type<RangeBase>(sender, elementPosition)
-          || HitTestUtilities.HitTest4Type<ButtonBase>(sender, elementPosition)
           || HitTestUtilities.HitTest4Type<TextBoxBase>(sender, elementPosition)
           || HitTestUtilities.HitTest4Type<PasswordBox>(sender, elementPosition)
           || HitTestUtilities.HitTest4Type<ComboBox>(sender, elementPosition)
@@ -791,18 +790,22 @@ public static IDragSource DefaultDragHandler
     {
       if (m_DragInfo != null && !m_DragInProgress) {
 
-        // do nothing if mouse left button is released
-        if (e.LeftButton == MouseButtonState.Released)
-        {
+        // the start from the source
+        var dragStart = m_DragInfo.DragStartPosition;
+
+        // do nothing if mouse left button is released or the pointer is captured
+        if (e.LeftButton == MouseButtonState.Released) {
           m_DragInfo = null;
           return;
-        } 
+        }
 
-        var dragStart = m_DragInfo.DragStartPosition;
+        // current mouse position
         var position = e.GetPosition((IInputElement)sender);
 
-        if (Math.Abs(position.X - dragStart.X) > SystemParameters.MinimumHorizontalDragDistance ||
-            Math.Abs(position.Y - dragStart.Y) > SystemParameters.MinimumVerticalDragDistance) {
+        // only if the sender is the source control and the mouse point differs from an offset
+        if (m_DragInfo.VisualSource == sender
+            && (Math.Abs(position.X - dragStart.X) > SystemParameters.MinimumHorizontalDragDistance ||
+                Math.Abs(position.Y - dragStart.Y) > SystemParameters.MinimumVerticalDragDistance)) {
           var dragHandler = TryGetDragHandler(m_DragInfo, sender as UIElement);
           if (dragHandler.CanStartDrag(m_DragInfo)) {
             dragHandler.StartDrag(m_DragInfo);

--- a/src/Showcase.WPF.DragDrop.NET45/Models/ItemModel.cs
+++ b/src/Showcase.WPF.DragDrop.NET45/Models/ItemModel.cs
@@ -1,7 +1,10 @@
-﻿using System.Collections.ObjectModel;
+﻿using System;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using System.Windows.Input;
 using JetBrains.Annotations;
+using Showcase.WPF.DragDrop.ViewModels;
 
 namespace Showcase.WPF.DragDrop.Models
 {
@@ -15,7 +18,7 @@ namespace Showcase.WPF.DragDrop.Models
       this.BindableDoubleValue = Faker.RandomNumber.Next(0, 100);
       for (int i = 0; i < Faker.RandomNumber.Next(2, 20); i++)
       {
-        SubItemCollection.Add($"Sub item {i}");
+        SubItemCollection.Add(new SubItemModel($"Sub item {i}"));
       }
     }
 
@@ -28,7 +31,8 @@ namespace Showcase.WPF.DragDrop.Models
     public int Index { get; set; }
     public string Caption { get; set; }
 
-    public ObservableCollection<string> SubItemCollection { get; set; } = new ObservableCollection<string>();
+    public ObservableCollection<SubItemModel> SubItemCollection { get; set; } = new ObservableCollection<SubItemModel>()
+      ;
 
     public string SelectedSubItem
     {
@@ -48,6 +52,69 @@ namespace Showcase.WPF.DragDrop.Models
       {
         if (value.Equals(_bindableDoubleValue)) return;
         _bindableDoubleValue = value;
+        OnPropertyChanged();
+      }
+    }
+
+    public override string ToString()
+    {
+      return this.Caption;
+    }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    [NotifyPropertyChangedInvocator]
+    protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+    {
+      PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+  }
+
+  public class SubItemModel : INotifyPropertyChanged
+  {
+    private string _bindableValue;
+    private bool _bindableOptionA;
+    private bool _bindableOptionB;
+
+    public SubItemModel(string caption)
+    {
+      this.Caption = caption;
+      this.ButtonTestCommand = new SimpleCommand(o => { this.BindableValue = $"Button clicked at {DateTime.UtcNow.ToLocalTime()}"; });
+    }
+
+    public string Caption { get; set; }
+
+    public ICommand ButtonTestCommand { get; set; }
+
+    public string BindableValue
+    {
+      get { return _bindableValue; }
+      set
+      {
+        if (value == _bindableValue) return;
+        _bindableValue = value;
+        OnPropertyChanged();
+      }
+    }
+
+    public bool BindableOptionA
+    {
+      get { return _bindableOptionA; }
+      set
+      {
+        if (value == _bindableOptionA) return;
+        _bindableOptionA = value;
+        OnPropertyChanged();
+      }
+    }
+
+    public bool BindableOptionB
+    {
+      get { return _bindableOptionB; }
+      set
+      {
+        if (value == _bindableOptionB) return;
+        _bindableOptionB = value;
         OnPropertyChanged();
       }
     }

--- a/src/Showcase.WPF.DragDrop.NET45/Views/MixedSamples.xaml
+++ b/src/Showcase.WPF.DragDrop.NET45/Views/MixedSamples.xaml
@@ -396,11 +396,22 @@
                                     dd:DragDrop.IsDropTarget="True"
                                     ItemsSource="{Binding SubItemCollection, Mode=OneWay}">
                         <ItemsControl.ItemTemplate>
-                          <DataTemplate>
+                          <DataTemplate DataType="{x:Type models:SubItemModel}">
                             <Grid Background="#FDA07E">
-                              <Button Content="{Binding}"
-                                      HorizontalAlignment="Left"
-                                      Margin="20,1,1,1" />
+                              <StackPanel Orientation="Horizontal">
+                                <Button Content="{Binding Caption}"
+                                        Command="{Binding ButtonTestCommand}"
+                                        VerticalAlignment="Center"
+                                        Margin="20 0 10 0" />
+                                <RadioButton Content="Option A"
+                                             VerticalAlignment="Center"
+                                             IsChecked="{Binding BindableOptionA}" />
+                                <RadioButton Content="Option B"
+                                             VerticalAlignment="Center"
+                                             IsChecked="{Binding BindableOptionB}" />
+                                <TextBlock Text="{Binding BindableValue}"
+                                           VerticalAlignment="Center" />
+                              </StackPanel>
                             </Grid>
                           </DataTemplate>
                         </ItemsControl.ItemTemplate>


### PR DESCRIPTION
Some fixes for the hit test problem

- Allow ButtonBase controls at mouse down of source control
- Test for the correct source start control at mouse move

Closes #213 Support for ControlTemplate types
Closes #212 No Handler is called if ListView is inside Expander in DataTemplate
Closes #145 Generalized drag-checks for scrollbar etc.