### PR TITLE
Only update TargetCollection and InsertIndex for expandedTVItem

### DIFF
--- a/src/GongSolutions.WPF.DragDrop.Shared/DropInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DropInfo.cs
@@ -154,7 +154,7 @@ namespace GongSolutions.Wpf.DragDrop
             }
 
             if (currentYPos > topGap && currentYPos < bottomGap) {
-              if (tvItem != null)
+              if (expandedTVItem)
               {
                 this.TargetCollection = tvItem.ItemsSource ?? tvItem.Items;
                 this.InsertIndex = this.TargetCollection != null ? this.TargetCollection.OfType<object>().Count() : 0;
@@ -184,7 +184,7 @@ namespace GongSolutions.Wpf.DragDrop
             }
 
             if (currentXPos > targetWidth * 0.25 && currentXPos < targetWidth * 0.75) {
-              if (tvItem != null)
+              if (expandedTVItem)
               {
                 this.TargetCollection = tvItem.ItemsSource ?? tvItem.Items;
                 this.InsertIndex = this.TargetCollection != null ? this.TargetCollection.OfType<object>().Count() : 0;


### PR DESCRIPTION
This commit will only set the InsertIndex when the treeViewItem is expanded.  This prevents the InsertIndex from being set to 0 and the adorner jumping to the top of the TreeView when the treeViewItem is not expanded and has no items.