### PR TITLE
Fix Issue 235 adds focus when clicking unfocused ListBox that switche…

### DIFF
--- a/src/GongSolutions.WPF.DragDrop.Shared/Utilities/ItemsControlExtensions.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/Utilities/ItemsControlExtensions.cs
@@ -295,6 +295,7 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
           ((ListBox)itemsControl).SelectionMode = SelectionMode.Single;
           ((ListBox)itemsControl).SelectedItem = null;
           ((ListBox)itemsControl).SelectedItem = item;
+          ((ListBox)itemsControl).Focus();
         }
         finally {
           ((ListBox)itemsControl).SelectionMode = selectionMode;


### PR DESCRIPTION
…s SelectionMode.

## What changed?
One line added to ItemsControlExtensions to add focus on the clicked ListBox.
_Describe the changes you have made to improve this project._
When switching from SelectionMode.Extended to Single we need to make sure we are focused on what was clicked.
_Closed issues._
235