### PR TITLE
Fix IDropInfo.Data when dragging from an ItemsControl using a CollectionViewSource with groups

### DIFF
--- a/src/GongSolutions.WPF.DragDrop.Shared/Utilities/ItemsControlExtensions.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/Utilities/ItemsControlExtensions.cs
@@ -210,6 +210,7 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
             // Ensure that this actually *is* an item container by checking it with
             // ItemContainerGenerator.
             if (itemContainer != null &&
+                !(itemContainer is GroupItem) &&
                 itemsControl.ItemContainerGenerator.IndexFromContainer(itemContainer) != -1) {
               isItemContainer = true;
               return itemContainer.GetType();


### PR DESCRIPTION
# Overview
When dragging an item from an ItemsControl using a CollectionViewSource with groups, IDropInfo.Data was incorrectly referencing the item's group and not the item itself, causing unexpected behavior.

This fixed the issue in our use case, though I must say I'm not sure if it has any side effect.

## Sample code to illustrate the issue
```csharp
public class VM
{
  public CollectionViewSource ItemsCollectionViewSource { get; protected set; }

  public class Item
  {
    public string Name { get; set; }
    public string GroupName { get; set; }
  }

  public List<Item> items = new List<Item>()
  {
      new Item() { Name = "Item1", GroupName = "Group1" },
      new Item() { Name = "Item2", GroupName = "Group1" },
      new Item() { Name = "Item3", GroupName = "Group2" },
      new Item() { Name = "Item4", GroupName = "Group2" },
      new Item() { Name = "Item5", GroupName = "Group3" },
  };

  public VM()
  {
    this.ItemsCollectionViewSource = new CollectionViewSource() { Source = items };
    this.ItemsCollectionViewSource.GroupDescriptions.Add(new PropertyGroupDescription() { PropertyName = "GroupName" });
  }
}
```
```xaml
<ItemsControl ItemsSource="{Binding VM.ItemsCollectionViewSource.View}"
              dd:DragDrop.IsDragSource="True"
              dd:DragDrop.IsDropTarget="True"
              dd:DragDrop.DragAdornerTemplate="{StaticResource DragAdorner}"
              dd:DragDrop.UseDefaultEffectDataTemplate="True">
  <ItemsControl.GroupStyle>
    <GroupStyle>
      <GroupStyle.HeaderTemplate>
        <DataTemplate>
          <TextBlock Text="{Binding Name}" />
        </DataTemplate>
      </GroupStyle.HeaderTemplate>
    </GroupStyle>
  </ItemsControl.GroupStyle>
</ItemsControl>
```
With this configuration, when dragging from the ItemsControl, the following error is thrown before fix is applied:
```
System.ArgumentException occurred
  HResult=0x80070057
  Message=The value "MS.Internal.Data.CollectionViewGroupInternal" is not of type "Showcase.WPF.DragDrop.ViewModels.DropHandlerVM+Item" and cannot be used in this generic collection.
  Source=mscorlib
  StackTrace:
   at System.ThrowHelper.ThrowWrongValueTypeArgumentException(Object value, Type targetType)
   at System.Collections.Generic.List`1.System.Collections.IList.Insert(Int32 index, Object item)
   at GongSolutions.Wpf.DragDrop.DefaultDropHandler.Drop(IDropInfo dropInfo) in C:\Users\<redacted>\Downloads\Git\gong-wpf-dragdrop\src\GongSolutions.WPF.DragDrop.Shared\DefaultDropHandler.cs:line 132
   at GongSolutions.Wpf.DragDrop.DragDrop.DropTargetOnDrop(Object sender, DragEventArgs e) in C:\Users\<redacted>\Downloads\Git\gong-wpf-dragdrop\src\GongSolutions.WPF.DragDrop.Shared\DragDrop.cs:line 632
   at System.Windows.DragEventArgs.InvokeEventHandler(Delegate genericHandler, Object genericTarget)
   at System.Windows.RoutedEventArgs.InvokeHandler(Delegate handler, Object target)
   at System.Windows.RoutedEventHandlerInfo.InvokeHandler(Object target, RoutedEventArgs routedEventArgs)
   at System.Windows.EventRoute.InvokeHandlersImpl(Object source, RoutedEventArgs args, Boolean reRaised)
   at System.Windows.UIElement.RaiseEventImpl(DependencyObject sender, RoutedEventArgs args)
   at System.Windows.UIElement.RaiseEvent(RoutedEventArgs e)
   at System.Windows.OleDropTarget.RaiseDragEvent(RoutedEvent dragEvent, Int32 dragDropKeyStates, Int32& effects, DependencyObject target, Point targetPoint)
   at System.Windows.OleDropTarget.MS.Win32.UnsafeNativeMethods.IOleDropTarget.OleDrop(Object data, Int32 dragDropKeyStates, Int64 point, Int32& effects)
```