### PR TITLE
Added ability to drag'n'drop outside of your window

### DIFF
--- a/src/GongSolutions.WPF.DragDrop.Shared/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DragDrop.cs
@@ -9,6 +9,7 @@ using System.Windows.Media;
 using GongSolutions.Wpf.DragDrop.Icons;
 using GongSolutions.Wpf.DragDrop.Utilities;
 using System.Windows.Media.Imaging;
+using GongSolutions.WPF.DragDrop.Shared;
 #if NET35
 using Microsoft.Windows.Controls;
 #endif
@@ -452,9 +453,9 @@ namespace GongSolutions.Wpf.DragDrop
               var data = dragInfo.DataObject;
 
               if (data == null) {
-                data = new DataObject(DataFormat.Name, dragInfo.Data);
+                data = new DataObject(DataFormat.Name, new DragDropDataWrapper(dragInfo.Data));
               } else {
-                data.SetData(DataFormat.Name, dragInfo.Data);
+                data.SetData(DataFormat.Name, new DragDropDataWrapper(dragInfo.Data));
               }
 
               try {

--- a/src/GongSolutions.WPF.DragDrop.Shared/DragDropDataWrapper.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DragDropDataWrapper.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace GongSolutions.WPF.DragDrop.Shared
+{
+  [Serializable]
+  public class DragDropDataWrapper : ISerializable
+  {
+    public DragDropDataWrapper(object innerData)
+    {
+      InnerData = innerData;
+    }
+
+    public DragDropDataWrapper(SerializationInfo info, StreamingContext context)
+    {
+      if (info == null) throw new ArgumentNullException("info");
+
+      InnerData = info.GetValue("InnerData", typeof(object));
+    }
+
+    public object InnerData { get; set; }
+
+    public void GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+      if (info == null) throw new ArgumentNullException("info");
+
+      info.AddValue("InnerData", InnerData);
+    }
+  }
+}

--- a/src/GongSolutions.WPF.DragDrop.Shared/DropInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DropInfo.cs
@@ -6,6 +6,7 @@ using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using GongSolutions.Wpf.DragDrop.Utilities;
 using System.Windows.Data;
+using GongSolutions.WPF.DragDrop.Shared;
 
 namespace GongSolutions.Wpf.DragDrop
 {
@@ -41,7 +42,8 @@ namespace GongSolutions.Wpf.DragDrop
     public DropInfo(object sender, DragEventArgs e, DragInfo dragInfo)
     {
       var dataFormat = DragDrop.DataFormat.Name;
-      this.Data = (e.Data.GetDataPresent(dataFormat)) ? e.Data.GetData(dataFormat) : e.Data;
+      this.Data = e.Data.GetDataPresent(dataFormat) ? e.Data.GetData(dataFormat) : e.Data;
+      if (this.Data is DragDropDataWrapper) this.Data = (this.Data as DragDropDataWrapper).InnerData;
       this.DragInfo = dragInfo;
       this.KeyStates = e.KeyStates;
 

--- a/src/GongSolutions.WPF.DragDrop.Shared/GongSolutions.WPF.DragDrop.Shared.projitems
+++ b/src/GongSolutions.WPF.DragDrop.Shared/GongSolutions.WPF.DragDrop.Shared.projitems
@@ -14,6 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)DragAdorner.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DragDrop.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DragDrop.Properties.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)DragDropDataWrapper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DragInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DropInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DropTargetAdorner.cs" />


### PR DESCRIPTION
I needed this feature in order to be able to drag'n'drop between multiple instances of my app. 

This is related with #29 and #136. It implements the idea from @LucaGanio in his comment https://github.com/punker76/gong-wpf-dragdrop/issues/29#issuecomment-188136430

## What changed?

The main change is to wrap the dragInfo.Data object into a Serializable Object, otherwise an exception like described in #29 will be raised. The only further requirement to the data object is, that it implements the SerializableAttribute.