### PR TITLE
Added custom effect text

### DIFF
--- a/src/GongSolutions.WPF.DragDrop.Shared/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DragDrop.cs
@@ -146,7 +146,7 @@ namespace GongSolutions.Wpf.DragDrop
       }
     }
 
-    private static DataTemplate GetEffectAdornerTemplate(UIElement target, DragDropEffects effect, string destinationText, string effectText = "")
+    private static DataTemplate GetEffectAdornerTemplate(UIElement target, DragDropEffects effect, string destinationText, string effectText = null)
     {
       switch (effect)
       {
@@ -154,13 +154,13 @@ namespace GongSolutions.Wpf.DragDrop
           // TODO: Add default template for EffectAll
           return GetEffectAllAdornerTemplate(target);
         case DragDropEffects.Copy:
-          return GetEffectCopyAdornerTemplate(target) ?? CreateDefaultEffectDataTemplate(target, IconFactory.EffectCopy, string.IsNullOrEmpty(effectText) ? "Copy to" : effectText, destinationText);
+          return GetEffectCopyAdornerTemplate(target) ?? CreateDefaultEffectDataTemplate(target, IconFactory.EffectCopy, effectText == null ? "Copy to" : effectText, destinationText);
         case DragDropEffects.Link:
-          return GetEffectLinkAdornerTemplate(target) ?? CreateDefaultEffectDataTemplate(target, IconFactory.EffectLink, string.IsNullOrEmpty(effectText) ? "Link to" : effectText, destinationText);
+          return GetEffectLinkAdornerTemplate(target) ?? CreateDefaultEffectDataTemplate(target, IconFactory.EffectLink, effectText == null ? "Link to" : effectText, destinationText);
         case DragDropEffects.Move:
-          return GetEffectMoveAdornerTemplate(target) ?? CreateDefaultEffectDataTemplate(target, IconFactory.EffectMove, string.IsNullOrEmpty(effectText) ? "Move to" : effectText, destinationText);
+          return GetEffectMoveAdornerTemplate(target) ?? CreateDefaultEffectDataTemplate(target, IconFactory.EffectMove, effectText == null ? "Move to" : effectText, destinationText);
         case DragDropEffects.None:
-          return GetEffectNoneAdornerTemplate(target) ?? CreateDefaultEffectDataTemplate(target, IconFactory.EffectNone, string.IsNullOrEmpty(effectText) ? "None" : effectText, destinationText);
+          return GetEffectNoneAdornerTemplate(target) ?? CreateDefaultEffectDataTemplate(target, IconFactory.EffectNone, effectText == null ?  "None" : effectText, destinationText);
         case DragDropEffects.Scroll:
           // TODO: Add default template EffectScroll
           return GetEffectScrollAdornerTemplate(target);
@@ -168,7 +168,6 @@ namespace GongSolutions.Wpf.DragDrop
           return null;
       }
     }
-
 
     private static DataTemplate CreateDefaultEffectDataTemplate(UIElement target, BitmapImage effectIcon, string effectText, string destinationText)
     {

--- a/src/GongSolutions.WPF.DragDrop.Shared/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DragDrop.cs
@@ -133,7 +133,7 @@ namespace GongSolutions.Wpf.DragDrop
     private static void CreateEffectAdorner(DropInfo dropInfo)
     {
       var dragInfo = m_DragInfo;
-      var template = GetEffectAdornerTemplate(dragInfo.VisualSource, dropInfo.Effects, dropInfo.DestinationText);
+      var template = GetEffectAdornerTemplate(dragInfo.VisualSource, dropInfo.Effects, dropInfo.DestinationText, dropInfo.EffectText);
 
       if (template != null) {
         var rootElement = RootElementFinder.FindRoot(dropInfo.VisualTarget ?? dragInfo.VisualSource);
@@ -146,7 +146,7 @@ namespace GongSolutions.Wpf.DragDrop
       }
     }
 
-    private static DataTemplate GetEffectAdornerTemplate(UIElement target, DragDropEffects effect, string destinationText)
+    private static DataTemplate GetEffectAdornerTemplate(UIElement target, DragDropEffects effect, string destinationText, string effectText)
     {
       switch (effect)
       {
@@ -154,13 +154,13 @@ namespace GongSolutions.Wpf.DragDrop
           // TODO: Add default template for EffectAll
           return GetEffectAllAdornerTemplate(target);
         case DragDropEffects.Copy:
-          return GetEffectCopyAdornerTemplate(target) ?? CreateDefaultEffectDataTemplate(target, IconFactory.EffectCopy, "Copy to", destinationText);
+          return GetEffectCopyAdornerTemplate(target) ?? CreateDefaultEffectDataTemplate(target, IconFactory.EffectCopy, effectText == string.Empty ? "Copy to" : effectText, destinationText);
         case DragDropEffects.Link:
-          return GetEffectLinkAdornerTemplate(target) ?? CreateDefaultEffectDataTemplate(target, IconFactory.EffectLink, "Link to", destinationText);
+          return GetEffectLinkAdornerTemplate(target) ?? CreateDefaultEffectDataTemplate(target, IconFactory.EffectLink, effectText == string.Empty ? "Link to" : effectText, destinationText);
         case DragDropEffects.Move:
-          return GetEffectMoveAdornerTemplate(target) ?? CreateDefaultEffectDataTemplate(target, IconFactory.EffectMove, "Move to", destinationText);
+          return GetEffectMoveAdornerTemplate(target) ?? CreateDefaultEffectDataTemplate(target, IconFactory.EffectMove, effectText == string.Empty ? "Move to" : effectText, destinationText);
         case DragDropEffects.None:
-          return GetEffectNoneAdornerTemplate(target) ?? CreateDefaultEffectDataTemplate(target, IconFactory.EffectNone, "None", destinationText);
+          return GetEffectNoneAdornerTemplate(target) ?? CreateDefaultEffectDataTemplate(target, IconFactory.EffectNone, effectText == string.Empty ? "None" : effectText, destinationText);
         case DragDropEffects.Scroll:
           // TODO: Add default template EffectScroll
           return GetEffectScrollAdornerTemplate(target);
@@ -168,6 +168,7 @@ namespace GongSolutions.Wpf.DragDrop
           return null;
       }
     }
+
 
     private static DataTemplate CreateDefaultEffectDataTemplate(UIElement target, BitmapImage effectIcon, string effectText, string destinationText)
     {

--- a/src/GongSolutions.WPF.DragDrop.Shared/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DragDrop.cs
@@ -146,7 +146,7 @@ namespace GongSolutions.Wpf.DragDrop
       }
     }
 
-    private static DataTemplate GetEffectAdornerTemplate(UIElement target, DragDropEffects effect, string destinationText, string effectText)
+    private static DataTemplate GetEffectAdornerTemplate(UIElement target, DragDropEffects effect, string destinationText, string effectText = "")
     {
       switch (effect)
       {
@@ -154,13 +154,13 @@ namespace GongSolutions.Wpf.DragDrop
           // TODO: Add default template for EffectAll
           return GetEffectAllAdornerTemplate(target);
         case DragDropEffects.Copy:
-          return GetEffectCopyAdornerTemplate(target) ?? CreateDefaultEffectDataTemplate(target, IconFactory.EffectCopy, effectText == string.Empty ? "Copy to" : effectText, destinationText);
+          return GetEffectCopyAdornerTemplate(target) ?? CreateDefaultEffectDataTemplate(target, IconFactory.EffectCopy, string.IsNullOrEmpty(effectText) ? "Copy to" : effectText, destinationText);
         case DragDropEffects.Link:
-          return GetEffectLinkAdornerTemplate(target) ?? CreateDefaultEffectDataTemplate(target, IconFactory.EffectLink, effectText == string.Empty ? "Link to" : effectText, destinationText);
+          return GetEffectLinkAdornerTemplate(target) ?? CreateDefaultEffectDataTemplate(target, IconFactory.EffectLink, string.IsNullOrEmpty(effectText) ? "Link to" : effectText, destinationText);
         case DragDropEffects.Move:
-          return GetEffectMoveAdornerTemplate(target) ?? CreateDefaultEffectDataTemplate(target, IconFactory.EffectMove, effectText == string.Empty ? "Move to" : effectText, destinationText);
+          return GetEffectMoveAdornerTemplate(target) ?? CreateDefaultEffectDataTemplate(target, IconFactory.EffectMove, string.IsNullOrEmpty(effectText) ? "Move to" : effectText, destinationText);
         case DragDropEffects.None:
-          return GetEffectNoneAdornerTemplate(target) ?? CreateDefaultEffectDataTemplate(target, IconFactory.EffectNone, effectText == string.Empty ? "None" : effectText, destinationText);
+          return GetEffectNoneAdornerTemplate(target) ?? CreateDefaultEffectDataTemplate(target, IconFactory.EffectNone, string.IsNullOrEmpty(effectText) ? "None" : effectText, destinationText);
         case DragDropEffects.Scroll:
           // TODO: Add default template EffectScroll
           return GetEffectScrollAdornerTemplate(target);

--- a/src/GongSolutions.WPF.DragDrop.Shared/DropInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DropInfo.cs
@@ -348,6 +348,12 @@ namespace GongSolutions.Wpf.DragDrop
     public string DestinationText { get; set; }
 
     /// <summary>
+    /// Gets and sets the effect text displayed in the DropDropEffects adorner.
+    /// </summary>
+    public string EffectText { get; set; }
+
+
+    /// <summary>
     /// Gets the relative position the item will be inserted to compared to the TargetItem
     /// </summary>
     public RelativeInsertPosition InsertPosition { get; private set; }

--- a/src/GongSolutions.WPF.DragDrop.Shared/DropInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DropInfo.cs
@@ -352,7 +352,6 @@ namespace GongSolutions.Wpf.DragDrop
     /// </summary>
     public string EffectText { get; set; }
 
-
     /// <summary>
     /// Gets the relative position the item will be inserted to compared to the TargetItem
     /// </summary>

--- a/src/GongSolutions.WPF.DragDrop.Shared/IDropInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/IDropInfo.cs
@@ -123,6 +123,11 @@ namespace GongSolutions.Wpf.DragDrop
     string DestinationText { get; set; }
 
     /// <summary>
+    /// Gets and sets the effect text displayed in the DropDropEffects adorner.
+    /// </summary>
+    string EffectText { get; set; }
+
+    /// <summary>
     /// Gets the relative position the item will be inserted to compared to the TargetItem
     /// </summary>
     RelativeInsertPosition InsertPosition { get; }


### PR DESCRIPTION
## Custom effect text

I've added the feature to customize the text which pops up when you drag an item by adding an optional argument to the GetEffectAdornerTemplate function.
Before, you only could choose between "Move to", "Copy to", "Link to" and no text at all.
If you leave the string empty or null the default strings will be used.

I extended the IDropInfo interface with the EffectText string.
