### PR TITLE
(#264) Fix Ctrl-Click and drag only drags most recently selected item

### DIFF
--- a/src/GongSolutions.WPF.DragDrop.Shared/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DragDrop.cs
@@ -444,6 +444,9 @@ namespace GongSolutions.Wpf.DragDrop
         if (dragInfo.VisualSource == sender
             && (Math.Abs(position.X - dragStart.X) > SystemParameters.MinimumHorizontalDragDistance ||
                 Math.Abs(position.Y - dragStart.Y) > SystemParameters.MinimumVerticalDragDistance)) {
+
+          dragInfo.RefreshSourceValues(sender, e);
+
           var dragHandler = TryGetDragHandler(dragInfo, sender as UIElement);
           if (dragHandler.CanStartDrag(dragInfo)) {
             dragHandler.StartDrag(dragInfo);

--- a/src/GongSolutions.WPF.DragDrop.Shared/DragInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DragInfo.cs
@@ -32,12 +32,15 @@ namespace GongSolutions.Wpf.DragDrop
     /// </param>
     public DragInfo(object sender, MouseButtonEventArgs e)
     {
-      this.DragStartPosition = e.GetPosition((IInputElement)sender);
       this.Effects = DragDropEffects.None;
       this.MouseButton = e.ChangedButton;
       this.VisualSource = sender as UIElement;
       this.DragDropCopyKeyState = DragDrop.GetDragDropCopyKeyState(this.VisualSource);
+      this.RefreshSourceValues(sender, e);
+    }
 
+    internal void RefreshSourceValues(object sender, MouseEventArgs e)
+    {
       var sourceElement = e.OriginalSource as UIElement;
       // If we can't cast object as a UIElement it might be a FrameworkContentElement, if so try and use its parent.
       if (sourceElement == null && e.OriginalSource is FrameworkContentElement)
@@ -47,6 +50,8 @@ namespace GongSolutions.Wpf.DragDrop
 
       if (sender is ItemsControl) {
         var itemsControl = (ItemsControl)sender;
+
+        this.DragStartPosition = e.GetPosition((IInputElement)sender);
 
         this.SourceGroup = itemsControl.FindGroup(this.DragStartPosition);
         this.VisualSourceFlowDirection = itemsControl.GetItemsPanelFlowDirection();


### PR DESCRIPTION
The main problem for this issue and #258 is that in the previewed mouse down event the selected items are still the previous ones.

Closed #264 
Relates to #264 