### PR TITLE
New attached property ShowAlwaysDropTargetAdorner

### DIFF
--- a/src/GongSolutions.WPF.DragDrop.Shared/DragDrop.Properties.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DragDrop.Properties.cs
@@ -256,6 +256,31 @@ namespace GongSolutions.Wpf.DragDrop
         }
 
         /// <summary>
+        /// Gets or Sets whether to show the DropTargetAdorner (DropTargetInsertionAdorner) on an empty target too.
+        /// </summary>
+        public static readonly DependencyProperty ShowAlwaysDropTargetAdornerProperty
+            = DependencyProperty.RegisterAttached("ShowAlwaysDropTargetAdorner",
+                                                  typeof(bool),
+                                                  typeof(DragDrop),
+                                                  new PropertyMetadata(false));
+
+        /// <summary>
+        /// Gets whether to show the DropTargetAdorner (DropTargetInsertionAdorner) on an empty target too.
+        /// </summary>
+        public static bool GetShowAlwaysDropTargetAdorner(UIElement target)
+        {
+            return (bool)target.GetValue(ShowAlwaysDropTargetAdornerProperty);
+        }
+
+        /// <summary>
+        /// Sets whether to show the DropTargetAdorner (DropTargetInsertionAdorner) on an empty target too.
+        /// </summary>
+        public static void SetShowAlwaysDropTargetAdorner(UIElement target, bool value)
+        {
+            target.SetValue(ShowAlwaysDropTargetAdornerProperty, value);
+        }
+
+        /// <summary>
         /// Gets or Sets the brush for the DropTargetAdorner.
         /// </summary>
         public static readonly DependencyProperty DropTargetAdornerBrushProperty

--- a/src/GongSolutions.WPF.DragDrop.Shared/DropTargetInsertionAdorner.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DropTargetInsertionAdorner.cs
@@ -72,6 +72,12 @@ namespace GongSolutions.Wpf.DragDrop
 
                 var itemContainer = (UIElement)itemParent.ItemContainerGenerator.ContainerFromIndex(index);
 
+                var showAlwaysDropTargetAdorner = itemContainer == null && DragDrop.GetShowAlwaysDropTargetAdorner(itemParent);
+                if (showAlwaysDropTargetAdorner)
+                {
+                    itemContainer = itemParent;
+                }
+
                 if (itemContainer != null)
                 {
                     var itemRect = new Rect(itemContainer.TranslatePoint(new Point(), this.AdornedElement), itemContainer.RenderSize);
@@ -84,9 +90,16 @@ namespace GongSolutions.Wpf.DragDrop
 
                     if (dropInfo.VisualTargetOrientation == Orientation.Vertical)
                     {
-                        if (dropInfo.InsertIndex == itemsCount || lastItemInGroup)
+                        if ((dropInfo.InsertIndex == itemsCount) || lastItemInGroup)
                         {
-                            itemRect.Y += itemContainer.RenderSize.Height;
+                            if (itemsCount > 0)
+                            {
+                                itemRect.Y += itemContainer.RenderSize.Height;
+                            }
+                            else
+                            {
+                                itemRect.Y += this.Pen.Thickness;
+                            }
                         }
 
                         var itemRectRight = Math.Min(itemRect.Right, viewportWidth);
@@ -96,19 +109,34 @@ namespace GongSolutions.Wpf.DragDrop
                     }
                     else
                     {
-                        var itemRectX = itemRect.X;
-
                         if (dropInfo.VisualTargetFlowDirection == FlowDirection.LeftToRight && dropInfo.InsertIndex == itemsCount)
                         {
-                            itemRectX += itemContainer.RenderSize.Width;
+                            if (itemsCount > 0)
+                            {
+                                itemRect.X += itemContainer.RenderSize.Width;
+                            }
+                            else
+                            {
+                                itemRect.X += this.Pen.Thickness;
+                            }
                         }
                         else if (dropInfo.VisualTargetFlowDirection == FlowDirection.RightToLeft && dropInfo.InsertIndex != itemsCount)
                         {
-                            itemRectX += itemContainer.RenderSize.Width;
+                            if (itemsCount > 0)
+                            {
+                                itemRect.X += itemContainer.RenderSize.Width;
+                            }
+                            else
+                            {
+                                itemRect.X += this.Pen.Thickness;
+                            }
                         }
 
-                        point1 = new Point(itemRectX, itemRect.Y);
-                        point2 = new Point(itemRectX, itemRect.Bottom);
+                        var itemRectTop = itemRect.Y < 0 ? 0 : itemRect.Y;
+                        var itemRectBottom = Math.Min(itemRect.Bottom, viewportHeight);
+
+                        point1 = new Point(itemRect.X, itemRectTop);
+                        point2 = new Point(itemRect.X, itemRectBottom);
                         rotation = 90;
                     }
 

--- a/src/Showcase.WPF.DragDrop.NET45/Views/ListBoxSamples.xaml
+++ b/src/Showcase.WPF.DragDrop.NET45/Views/ListBoxSamples.xaml
@@ -39,6 +39,7 @@
                                          ItemsSource="{Binding Data.Collection1}" />
                                 <ListBox Grid.Column="1"
                                          dd:DragDrop.DropTargetAdornerBrush="Coral"
+                                         dd:DragDrop.ShowAlwaysDropTargetAdorner="True"
                                          dd:DragDrop.IsDragSource="True"
                                          dd:DragDrop.IsDropTarget="True"
                                          ItemsSource="{Binding Data.Collection2}" />


### PR DESCRIPTION
The ShowAlwaysDropTargetAdorner gets or sets whether to show the DropTargetAdorner (DropTargetInsertionAdorner) on an empty target too.

Closes #203 
Relates to #203 