### PR TITLE
(#269) Using own DataFormat for Drag&Drop action

### DIFF
--- a/src/GongSolutions.WPF.DragDrop.Shared/DragDrop.Properties.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DragDrop.Properties.cs
@@ -7,7 +7,35 @@ namespace GongSolutions.Wpf.DragDrop
 {
     public static partial class DragDrop
     {
+        /// <summary>
+        /// The default data format which will be used for the drag and drop actions.
+        /// </summary>
         public static DataFormat DataFormat { get; } = DataFormats.GetDataFormat("GongSolutions.Wpf.DragDrop");
+
+        /// <summary>
+        /// Gets or sets the data format which will be used for the drag and drop actions.
+        /// </summary>
+        public static readonly DependencyProperty DataFormatProperty
+            = DependencyProperty.RegisterAttached("DataFormat",
+                                                  typeof(DataFormat),
+                                                  typeof(DragDrop),
+                                                  new PropertyMetadata(DragDrop.DataFormat));
+
+        /// <summary>
+        /// Gets the data format which will be used for the drag and drop actions.
+        /// </summary>
+        public static DataFormat GetDataFormat(UIElement source)
+        {
+            return (DataFormat)source.GetValue(DataFormatProperty);
+        }
+
+        /// <summary>
+        /// Sets the data format which will be used for the drag and drop actions.
+        /// </summary>
+        public static void SetDataFormat(UIElement source, DataFormat value)
+        {
+            source.SetValue(DataFormatProperty, value);
+        }
 
         /// <summary>
         /// Gets or Sets whether the control can be used as drag source.

--- a/src/GongSolutions.WPF.DragDrop.Shared/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DragDrop.cs
@@ -491,7 +491,7 @@ namespace GongSolutions.Wpf.DragDrop
                                     m_DragInfo = null; // maybe not necessary or should not set here to null
                                     return;
                                 }
-                                dataObject = new DataObject(DataFormat.Name, dragInfo.Data);
+                                dataObject = new DataObject(dragInfo.DataFormat.Name, dragInfo.Data);
                             }
 
                             try

--- a/src/GongSolutions.WPF.DragDrop.Shared/DragInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DragInfo.cs
@@ -36,6 +36,11 @@ namespace GongSolutions.Wpf.DragDrop
             this.MouseButton = e.ChangedButton;
             this.VisualSource = sender as UIElement;
             this.DragDropCopyKeyState = DragDrop.GetDragDropCopyKeyState(this.VisualSource);
+            var dataFormat = DragDrop.GetDataFormat(this.VisualSource);
+            if (dataFormat != null)
+            {
+                this.DataFormat = dataFormat;
+            }
 
             var sourceElement = e.OriginalSource as UIElement;
             // If we can't cast object as a UIElement it might be a FrameworkContentElement, if so try and use its parent.
@@ -162,6 +167,12 @@ namespace GongSolutions.Wpf.DragDrop
                 }
             }
         }
+
+        /// <summary>
+        /// Gets or sets the data format which will be used for the drag and drop actions.
+        /// </summary>
+        /// <value>The data format.</value>
+        public DataFormat DataFormat { get; set; } = DragDrop.DataFormat;
 
         /// <summary>
         /// Gets or sets the drag data.

--- a/src/GongSolutions.WPF.DragDrop.Shared/DropInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DropInfo.cs
@@ -41,7 +41,7 @@ namespace GongSolutions.Wpf.DragDrop
         /// </param>
         public DropInfo(object sender, DragEventArgs e, DragInfo dragInfo)
         {
-            var dataFormat = DragDrop.DataFormat.Name;
+            var dataFormat = dragInfo.DataFormat.Name;
             this.Data = (e.Data.GetDataPresent(dataFormat)) ? e.Data.GetData(dataFormat) : e.Data;
             this.DragInfo = dragInfo;
             this.KeyStates = e.KeyStates;

--- a/src/GongSolutions.WPF.DragDrop.Shared/DropInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DropInfo.cs
@@ -7,6 +7,7 @@ using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Media;
 using GongSolutions.Wpf.DragDrop.Utilities;
+using JetBrains.Annotations;
 
 namespace GongSolutions.Wpf.DragDrop
 {
@@ -39,12 +40,12 @@ namespace GongSolutions.Wpf.DragDrop
         /// <param name="dragInfo">
         /// Information about the source of the drag, if the drag came from within the framework.
         /// </param>
-        public DropInfo(object sender, DragEventArgs e, DragInfo dragInfo)
+        public DropInfo(object sender, DragEventArgs e, [CanBeNull] DragInfo dragInfo)
         {
-            var dataFormat = dragInfo.DataFormat.Name;
-            this.Data = (e.Data.GetDataPresent(dataFormat)) ? e.Data.GetData(dataFormat) : e.Data;
             this.DragInfo = dragInfo;
             this.KeyStates = e.KeyStates;
+            var dataFormat = dragInfo?.DataFormat;
+            this.Data = dataFormat != null && e.Data.GetDataPresent(dataFormat.Name) ? e.Data.GetData(dataFormat.Name) : e.Data;
 
             this.VisualTarget = sender as UIElement;
             // if there is no drop target, find another

--- a/src/GongSolutions.WPF.DragDrop.Shared/IDragInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/IDragInfo.cs
@@ -8,6 +8,12 @@ namespace GongSolutions.Wpf.DragDrop
     public interface IDragInfo
     {
         /// <summary>
+        /// Gets or sets the data format which will be used for the drag and drop actions.
+        /// </summary>
+        /// <value>The data format.</value>
+        DataFormat DataFormat { get; set; }
+
+        /// <summary>
         /// Gets or sets the drag data.
         /// </summary>
         /// 


### PR DESCRIPTION
With these changes it will be possible to use a custom `DataFormat` for the drag&drop actions.

- New property `DataFormat` at `IDragInfo` (default is DragDrop.DataFormat)
- New attached property DataFormat (default is DragDrop.DataFormat)
- The DragInfo will use the default DragDrop.DataFormat if there is no DataFormat set via attached property. It's also possible to override this at the `StartDrag` method.
- The `DataObject` will then use the DataFormat from the drag info.

Closes #269 
Relates to #269 
