### PR TITLE
Drag&Drop from App to App

### DIFF
--- a/src/GongSolutions.WPF.DragDrop.Shared/DefaultDragHandler.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DefaultDragHandler.cs
@@ -53,6 +53,16 @@ namespace GongSolutions.Wpf.DragDrop
         }
 
         /// <summary>
+        /// Notifies the drag handler that a drag and drop operation has finished.
+        /// </summary>
+        /// <param name="operationResult">The operation result.</param>
+        /// <param name="dragInfo">The drag information.</param>
+        public virtual void DragDropOperationFinished(DragDropEffects operationResult, IDragInfo dragInfo)
+        {
+            // nothing here
+        }
+
+        /// <summary>
         /// Notifies the drag handler that a drag has been aborted.
         /// </summary>
         public virtual void DragCancelled()

--- a/src/GongSolutions.WPF.DragDrop.Shared/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DragDrop.cs
@@ -497,11 +497,12 @@ namespace GongSolutions.Wpf.DragDrop
                             try
                             {
                                 m_DragInProgress = true;
-                                var result = System.Windows.DragDrop.DoDragDrop(dragInfo.VisualSource, dataObject, dragInfo.Effects);
-                                if (result == DragDropEffects.None)
+                                var dragDropEffects = System.Windows.DragDrop.DoDragDrop(dragInfo.VisualSource, dataObject, dragInfo.Effects);
+                                if (dragDropEffects == DragDropEffects.None)
                                 {
                                     dragHandler.DragCancelled();
                                 }
+                                dragHandler.DragDropOperationFinished(dragDropEffects, dragInfo);
                             }
                             catch (Exception ex)
                             {
@@ -691,8 +692,10 @@ namespace GongSolutions.Wpf.DragDrop
             dropHandler.Drop(dropInfo);
             dragHandler.Dropped(dropInfo);
 
-            Mouse.OverrideCursor = null;
+            e.Effects = dropInfo.Effects;
             e.Handled = !dropInfo.NotHandled;
+
+            Mouse.OverrideCursor = null;
         }
 
         private static void DropTargetOnGiveFeedback(object sender, GiveFeedbackEventArgs e)

--- a/src/GongSolutions.WPF.DragDrop.Shared/IDragSource.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/IDragSource.cs
@@ -38,6 +38,13 @@ namespace GongSolutions.Wpf.DragDrop
         void Dropped(IDropInfo dropInfo);
 
         /// <summary>
+        /// Notifies the drag handler that a drag and drop operation has finished.
+        /// </summary>
+        /// <param name="operationResult">The operation result.</param>
+        /// <param name="dragInfo">The drag information.</param>
+        void DragDropOperationFinished(DragDropEffects operationResult, IDragInfo dragInfo);
+
+        /// <summary>
         /// Notifies the drag handler that a drag has been aborted.
         /// </summary>
         void DragCancelled();

--- a/src/Showcase.WPF.DragDrop.NET45/MainWindow.xaml
+++ b/src/Showcase.WPF.DragDrop.NET45/MainWindow.xaml
@@ -14,7 +14,7 @@
 
     <Grid>
 
-        <TabControl Style="{StaticResource ShowcaseTabControlStyle}">
+        <TabControl x:Name="MainTabControl" Style="{StaticResource ShowcaseTabControlStyle}">
             <TabItem Header="ListBox">
                 <views:ListBoxSamples />
             </TabItem>

--- a/src/Showcase.WPF.DragDrop.NET45/MainWindow.xaml.cs
+++ b/src/Showcase.WPF.DragDrop.NET45/MainWindow.xaml.cs
@@ -1,4 +1,7 @@
-﻿using System.Windows;
+﻿using System;
+using System.Linq;
+using System.Windows.Controls;
+using System.Windows;
 using Showcase.WPF.DragDrop.ViewModels;
 
 namespace Showcase.WPF.DragDrop
@@ -12,6 +15,16 @@ namespace Showcase.WPF.DragDrop
         {
             InitializeComponent();
             this.DataContext = new MainViewModel();
+            this.Loaded += MainWindowLoaded;
+        }
+
+        private void MainWindowLoaded(object sender, RoutedEventArgs e)
+        {
+            var appArgs = Environment.GetCommandLineArgs();
+            if (appArgs.Length > 1 && appArgs[1] == "anotherOne")
+            {
+                this.MainTabControl.SelectedItem = MainTabControl.Items.OfType<TabItem>().FirstOrDefault(t => (string)t.Header == "Mixed");
+            }
         }
     }
 }

--- a/src/Showcase.WPF.DragDrop.NET45/Models/ItemModel.cs
+++ b/src/Showcase.WPF.DragDrop.NET45/Models/ItemModel.cs
@@ -133,4 +133,23 @@ namespace Showcase.WPF.DragDrop.Models
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
+
+    [Serializable]
+    public class SerializableItemModel
+    {
+        public SerializableItemModel(int itemIndex)
+        {
+            this.Index = itemIndex;
+            this.Caption = $"{itemIndex}. Item";
+        }
+
+        public int Index { get; set; }
+
+        public string Caption { get; set; }
+
+        public override string ToString()
+        {
+            return this.Caption;
+        }
+    }
 }

--- a/src/Showcase.WPF.DragDrop.NET45/Models/SampleData.cs
+++ b/src/Showcase.WPF.DragDrop.NET45/Models/SampleData.cs
@@ -10,6 +10,7 @@ namespace Showcase.WPF.DragDrop.Models
         {
             for (var n = 0; n < 50; ++n)
             {
+                this.SerializableCollection1.Add(new SerializableItemModel(n + 1));
                 this.Collection1.Add(new ItemModel(n + 1));
                 this.FilterCollection1.Add(new ItemModel(n + 1));
                 this.ClonableCollection1.Add(new ClonableItemModel(n + 1));
@@ -51,6 +52,14 @@ namespace Showcase.WPF.DragDrop.Models
             }
             this.TabItemCollection2.Add(new TabItemModel(1));
         }
+
+        public ObservableCollection<SerializableItemModel> SerializableCollection1 { get; set; } = new ObservableCollection<SerializableItemModel>();
+
+        public ObservableCollection<SerializableItemModel> SerializableCollection2 { get; set; } = new ObservableCollection<SerializableItemModel>();
+
+        public SerializableDragHandler SerializableDragHandler { get; set; } = new SerializableDragHandler();
+
+        public SerializableDropHandler SerializableDropHandler { get; set; } = new SerializableDropHandler();
 
         public ObservableCollection<ItemModel> Collection1 { get; set; } = new ObservableCollection<ItemModel>();
 

--- a/src/Showcase.WPF.DragDrop.NET45/Models/SerializableDragHandler.cs
+++ b/src/Showcase.WPF.DragDrop.NET45/Models/SerializableDragHandler.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using GongSolutions.Wpf.DragDrop;
+using GongSolutions.Wpf.DragDrop.Utilities;
+
+namespace Showcase.WPF.DragDrop.Models
+{
+    [Serializable]
+    public class SerializableWrapper
+    {
+        public IEnumerable<object> Items { get; set; }
+
+        public DragDropKeyStates DragDropCopyKeyState { get; set; }
+    }
+
+    public class SerializableDragHandler : IDragSource
+    {
+        private bool alreadyDropped = false;
+
+        public void StartDrag(IDragInfo dragInfo)
+        {
+            alreadyDropped = false;
+            var items = dragInfo.SourceItems.OfType<object>().ToList();
+            var wrapper = new SerializableWrapper()
+                          {
+                              Items = items,
+                              DragDropCopyKeyState = DragDropKeyStates.ControlKey //dragInfo.DragDropCopyKeyState
+                          };
+            dragInfo.Data = wrapper;
+            dragInfo.DataFormat = DataFormats.GetDataFormat(DataFormats.Serializable);
+            dragInfo.Effects = dragInfo.Data != null ? DragDropEffects.Copy | DragDropEffects.Move : DragDropEffects.None;
+        }
+
+        public bool CanStartDrag(IDragInfo dragInfo)
+        {
+            return true;
+        }
+
+        public void Dropped(IDropInfo dropInfo)
+        {
+            alreadyDropped = true;
+        }
+
+        public void DragDropOperationFinished(DragDropEffects operationResult, IDragInfo dragInfo)
+        {
+            if (alreadyDropped || dragInfo == null)
+            {
+                return;
+            }
+
+            // the drag operation has finished on another app
+            if (operationResult != DragDropEffects.None)
+            {
+                if (operationResult.HasFlag(DragDropEffects.Move))
+                {
+                    var sourceList = dragInfo.SourceCollection.TryGetList();
+                    var items = dragInfo.SourceItems.OfType<object>().ToList();
+                    if (sourceList != null)
+                    {
+                        foreach (var o in items)
+                        {
+                            sourceList.Remove(o);
+                        }
+                    }
+                    alreadyDropped = true;
+                }
+            }
+        }
+
+        public void DragCancelled()
+        {
+        }
+
+        public bool TryCatchOccurredException(Exception exception)
+        {
+            return false;
+        }
+    }
+}

--- a/src/Showcase.WPF.DragDrop.NET45/Models/SerializableDropHandler.cs
+++ b/src/Showcase.WPF.DragDrop.NET45/Models/SerializableDropHandler.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Windows;
+using GongSolutions.Wpf.DragDrop;
+using GongSolutions.Wpf.DragDrop.Utilities;
+
+namespace Showcase.WPF.DragDrop.Models
+{
+    public class SerializableDropHandler : IDropTarget
+    {
+        public void DragOver(IDropInfo dropInfo)
+        {
+            var wrapper = GetSerializableWrapper(dropInfo);
+            if (wrapper != null && dropInfo.TargetCollection != null)
+            {
+                dropInfo.Effects = ShouldCopyData(dropInfo, wrapper.DragDropCopyKeyState) ? DragDropEffects.Copy : DragDropEffects.Move;
+                dropInfo.DropTargetAdorner = DropTargetAdorners.Insert;
+            }
+        }
+
+        public void Drop(IDropInfo dropInfo)
+        {
+            var wrapper = GetSerializableWrapper(dropInfo);
+            if (wrapper != null && dropInfo.TargetCollection != null)
+            {
+                // at this point the drag info can be null, cause the other app doesn't know it
+                var insertIndex = dropInfo.InsertIndex != dropInfo.UnfilteredInsertIndex ? dropInfo.UnfilteredInsertIndex : dropInfo.InsertIndex;
+                var destinationList = dropInfo.TargetCollection.TryGetList();
+                var copyData = ShouldCopyData(dropInfo, wrapper.DragDropCopyKeyState);
+
+                if (!copyData)
+                {
+                    var sourceList = dropInfo.DragInfo?.SourceCollection?.TryGetList();
+                    if (sourceList != null)
+                    {
+                        foreach (var o in wrapper.Items)
+                        {
+                            var index = sourceList.IndexOf(o);
+                            if (index != -1)
+                            {
+                                sourceList.RemoveAt(index);
+                                // so, is the source list the destination list too ?
+                                if (destinationList != null && Equals(sourceList, destinationList) && index < insertIndex)
+                                {
+                                    --insertIndex;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (destinationList != null)
+                {
+                    // check for cloning
+                    var cloneData = dropInfo.Effects.HasFlag(DragDropEffects.Copy)
+                                    || dropInfo.Effects.HasFlag(DragDropEffects.Link);
+                    foreach (var o in wrapper.Items)
+                    {
+                        var obj2Insert = o;
+                        if (cloneData)
+                        {
+                            var cloneable = o as ICloneable;
+                            if (cloneable != null)
+                            {
+                                obj2Insert = cloneable.Clone();
+                            }
+                        }
+
+                        destinationList.Insert(insertIndex++, obj2Insert);
+                    }
+                }
+            }
+        }
+
+        private static SerializableWrapper GetSerializableWrapper(IDropInfo dropInfo)
+        {
+            var data = dropInfo.Data;
+
+            var dataObject = data as DataObject;
+            if (dataObject != null)
+            {
+                var dataFormat = DataFormats.GetDataFormat(DataFormats.Serializable);
+                data = dataObject.GetDataPresent(dataFormat.Name) ? dataObject.GetData(dataFormat.Name) : data;
+            }
+
+            var wrapper = data as SerializableWrapper;
+            return wrapper;
+        }
+
+        private static bool ShouldCopyData(IDropInfo dropInfo, DragDropKeyStates dragDropCopyKeyState)
+        {
+            // default should always the move action/effect
+            if (dropInfo == null)
+            {
+                return false;
+            }
+            var copyData = ((dragDropCopyKeyState != default(DragDropKeyStates)) && dropInfo.KeyStates.HasFlag(dragDropCopyKeyState))
+                           || dragDropCopyKeyState.HasFlag(DragDropKeyStates.LeftMouseButton);
+            return copyData;
+        }
+    }
+}

--- a/src/Showcase.WPF.DragDrop.NET45/Showcase.WPF.DragDrop.NET45.csproj
+++ b/src/Showcase.WPF.DragDrop.NET45/Showcase.WPF.DragDrop.NET45.csproj
@@ -75,6 +75,8 @@
     <Compile Include="Models\ItemModel.cs" />
     <Compile Include="Models\ListBoxCustomDropHandler.cs" />
     <Compile Include="Models\SampleData.cs" />
+    <Compile Include="Models\SerializableDragHandler.cs" />
+    <Compile Include="Models\SerializableDropHandler.cs" />
     <Compile Include="Models\TabItemModel.cs" />
     <Compile Include="Models\TextBoxCustomDropHandler.cs" />
     <Compile Include="Models\TreeNode.cs" />

--- a/src/Showcase.WPF.DragDrop.NET45/Views/ListBoxSamples.xaml
+++ b/src/Showcase.WPF.DragDrop.NET45/Views/ListBoxSamples.xaml
@@ -39,9 +39,9 @@
                                          ItemsSource="{Binding Data.Collection1}" />
                                 <ListBox Grid.Column="1"
                                          dd:DragDrop.DropTargetAdornerBrush="Coral"
-                                         dd:DragDrop.ShowAlwaysDropTargetAdorner="True"
                                          dd:DragDrop.IsDragSource="True"
                                          dd:DragDrop.IsDropTarget="True"
+                                         dd:DragDrop.ShowAlwaysDropTargetAdorner="True"
                                          ItemsSource="{Binding Data.Collection2}" />
                             </Grid>
 

--- a/src/Showcase.WPF.DragDrop.NET45/Views/MixedSamples.xaml
+++ b/src/Showcase.WPF.DragDrop.NET45/Views/MixedSamples.xaml
@@ -19,7 +19,7 @@
             <Style BasedOn="{StaticResource DefaultTreeViewStyle}" TargetType="{x:Type TreeView}" />
         </Grid.Resources>
 
-        <TabControl Style="{StaticResource ShowcaseTabControlStyle}">
+        <TabControl x:Name="MixedTabControl" Style="{StaticResource ShowcaseTabControlStyle}">
 
             <TabControl.Resources>
                 <DataTemplate x:Key="DragAdorner">
@@ -439,6 +439,71 @@
                             </ItemsControl>
                         </ScrollViewer>
                     </DockPanel>
+                </DockPanel>
+            </TabItem>
+
+            <TabItem Header="Outside">
+                <TabItem.Resources />
+                <DockPanel LastChildFill="True">
+                    <StackPanel DockPanel.Dock="Top" Orientation="Vertical">
+                        <TextBlock Style="{StaticResource SampleHeaderTextBlockStyle}" Text="Drag and drop from one App to another one." />
+                        <TextBlock Style="{StaticResource DefaultTextBlockStyle}" Text="Demonstrates drag and drop action bewteen one application to another one. Just open the other app and try to drag one or more items to this app or vice versa." />
+                        <Button Margin="2"
+                                Click="ButtonOpenAnotherAppOnClick"
+                                Content="Open another application..." />
+                    </StackPanel>
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+
+                        <Grid Grid.Row="0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <ListBox x:Name="LeftBoundListBox"
+                                     Grid.Column="0"
+                                     Height="Auto"
+                                     dd:DragDrop.DragHandler="{Binding Data.SerializableDragHandler}"
+                                     dd:DragDrop.DropHandler="{Binding Data.SerializableDropHandler}"
+                                     dd:DragDrop.DropTargetAdornerBrush="BlueViolet"
+                                     dd:DragDrop.IsDragSource="True"
+                                     dd:DragDrop.IsDropTarget="True"
+                                     dd:DragDrop.UseDefaultEffectDataTemplate="True"
+                                     ItemsSource="{Binding Data.SerializableCollection1}" />
+                            <ListBox Grid.Column="1"
+                                     Height="Auto"
+                                     dd:DragDrop.DragHandler="{Binding Data.SerializableDragHandler}"
+                                     dd:DragDrop.DropHandler="{Binding Data.SerializableDropHandler}"
+                                     dd:DragDrop.DropTargetAdornerBrush="BlueViolet"
+                                     dd:DragDrop.IsDragSource="True"
+                                     dd:DragDrop.IsDropTarget="True"
+                                     dd:DragDrop.ShowAlwaysDropTargetAdorner="True"
+                                     dd:DragDrop.UseDefaultEffectDataTemplate="True"
+                                     ItemsSource="{Binding Data.SerializableCollection2}" />
+                        </Grid>
+
+                        <StackPanel Grid.Row="1">
+                            <TextBlock Style="{StaticResource DefaultTextBlockStyle}" Text="Customization (for left ListBox)" />
+                            <CheckBox Margin="10 5"
+                                      Content="IsDragSource"
+                                      IsChecked="{Binding ElementName=LeftBoundListBox, Path=(dd:DragDrop.IsDragSource), Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <CheckBox Margin="10 5"
+                                      Content="CanDragWithMouseRightButton"
+                                      IsChecked="{Binding ElementName=LeftBoundListBox, Path=(dd:DragDrop.CanDragWithMouseRightButton), Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <CheckBox Margin="10 5"
+                                      Content="IsDropTarget"
+                                      IsChecked="{Binding ElementName=LeftBoundListBox, Path=(dd:DragDrop.IsDropTarget), Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <CheckBox Margin="10 5"
+                                      Content="UseDefaultDragAdorner"
+                                      IsChecked="{Binding ElementName=LeftBoundListBox, Path=(dd:DragDrop.UseDefaultDragAdorner), Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <CheckBox Margin="10 5"
+                                      Content="UseDefaultEffectDataTemplate"
+                                      IsChecked="{Binding ElementName=LeftBoundListBox, Path=(dd:DragDrop.UseDefaultEffectDataTemplate), Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        </StackPanel>
+                    </Grid>
                 </DockPanel>
             </TabItem>
 

--- a/src/Showcase.WPF.DragDrop.NET45/Views/MixedSamples.xaml.cs
+++ b/src/Showcase.WPF.DragDrop.NET45/Views/MixedSamples.xaml.cs
@@ -1,6 +1,11 @@
-﻿#if !NET35
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+#if !NET35
 using System.Threading.Tasks;
 #endif
+using System.Windows;
 using System.Windows.Controls;
 
 namespace Showcase.WPF.DragDrop.Views
@@ -13,6 +18,21 @@ namespace Showcase.WPF.DragDrop.Views
         public MixedSamples()
         {
             InitializeComponent();
+            this.Loaded += MainWindowLoaded;
+        }
+
+        private void MainWindowLoaded(object sender, RoutedEventArgs e)
+        {
+            var appArgs = Environment.GetCommandLineArgs();
+            if (appArgs.Length > 1 && appArgs[1] == "anotherOne")
+            {
+                MixedTabControl.SelectedItem = MixedTabControl.Items.OfType<TabItem>().FirstOrDefault(t => (string)t.Header == "Outside");
+            }
+        }
+
+        private void ButtonOpenAnotherAppOnClick(object sender, RoutedEventArgs e)
+        {
+            Process.Start(Assembly.GetEntryAssembly().Location, "anotherOne");
         }
     }
 }


### PR DESCRIPTION
This PR adds a new method to the IDragSource interface and adds a sample to show a drag&drop from one app to another with a serializable model.

- New DragDropOperationFinished method for IDragSource
- Add serializable sample

![gong_dragdrop_to_another_app](https://user-images.githubusercontent.com/658431/32751514-7b24e85e-c8c6-11e7-9cf3-3ceffd25f243.gif)

Closes #254 
Closes #136 
Relates to #136 
Relates to #29 