### PR TITLE
Edited UnfilteredInsertIndex property

### DIFF
--- a/src/GongSolutions.WPF.DragDrop.Shared/DropInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DropInfo.cs
@@ -299,6 +299,14 @@ namespace GongSolutions.Wpf.DragDrop
                                 return indexOf;
                             }
                         }
+                        else if (itemParent.Items.Count > 0 && insertIndex == itemParent.Items.Count)
+                        {
+                            var indexOf = itemSourceAsList.IndexOf(itemParent.Items[insertIndex - 1]);
+                            if (indexOf >= 0)
+                            {
+                                return indexOf + 1;
+                            }
+                        }
                     }
                 }
                 return insertIndex;


### PR DESCRIPTION
UnfilteredInsertIndex returns incorrect index when item dropped at the end of a filtered list. This modification fixes this fault.
