### PR TITLE
New Feature: Select dropped items after drag&drop action

### DIFF
--- a/src/GongSolutions.WPF.DragDrop.Shared/DefaultDropHandler.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DefaultDropHandler.cs
@@ -5,8 +5,9 @@ using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Windows;
-using GongSolutions.Wpf.DragDrop.Utilities;
 using System.Windows.Controls;
+using GongSolutions.Wpf.DragDrop.Utilities;
+using JetBrains.Annotations;
 
 namespace GongSolutions.Wpf.DragDrop
 {
@@ -15,6 +16,112 @@ namespace GongSolutions.Wpf.DragDrop
     /// </summary>
     public class DefaultDropHandler : IDropTarget
     {
+        /// <summary>
+        /// Test the specified drop information for the right data.
+        /// </summary>
+        /// <param name="dropInfo">The drop information.</param>
+        public static bool CanAcceptData(IDropInfo dropInfo)
+        {
+            if (dropInfo == null || dropInfo.DragInfo == null)
+            {
+                return false;
+            }
+
+            if (!dropInfo.IsSameDragDropContextAsSource)
+            {
+                return false;
+            }
+
+            // do not drop on itself
+            var isTreeViewItem = dropInfo.InsertPosition.HasFlag(RelativeInsertPosition.TargetItemCenter)
+                                 && dropInfo.VisualTargetItem is TreeViewItem;
+            if (isTreeViewItem && dropInfo.VisualTargetItem == dropInfo.DragInfo.VisualSourceItem)
+            {
+                return false;
+            }
+
+            if (dropInfo.DragInfo.SourceCollection == dropInfo.TargetCollection)
+            {
+                var targetList = dropInfo.TargetCollection.TryGetList();
+                return targetList != null;
+            }
+            //      else if (dropInfo.DragInfo.SourceCollection is ItemCollection) {
+            //        return false;
+            //      }
+            else if (dropInfo.TargetCollection == null)
+            {
+                return false;
+            }
+            else
+            {
+                if (TestCompatibleTypes(dropInfo.TargetCollection, dropInfo.Data))
+                {
+                    var isChildOf = IsChildOf(dropInfo.VisualTargetItem, dropInfo.DragInfo.VisualSourceItem);
+                    return !isChildOf;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+
+        public static IEnumerable ExtractData(object data)
+        {
+            if (data is IEnumerable && !(data is string))
+            {
+                return (IEnumerable)data;
+            }
+            else
+            {
+                return Enumerable.Repeat(data, 1);
+            }
+        }
+
+        /// <summary>
+        /// Clears the current selected items and selects the given items.
+        /// </summary>
+        /// <param name="dropInfo">The drop information.</param>
+        /// <param name="items">The items which should be select.</param>
+        /// <param name="applyTemplate">if set to <c>true</c> then for all items the ApplyTemplate will be invoked.</param>
+        /// <param name="focusVisualTarget">if set to <c>true</c> the visual target will be focused.</param>
+        /// <exception cref="System.ArgumentNullException"><paramref name="dropInfo" /> is <see langword="null" /></exception>
+        /// <exception cref="System.ArgumentNullException"><paramref name="dropInfo" /> is <see langword="null" /></exception>
+        public static void SelectDroppedItems([NotNull] IDropInfo dropInfo, [NotNull] IEnumerable items, bool applyTemplate = true, bool focusVisualTarget = true)
+        {
+            if (dropInfo == null) throw new ArgumentNullException(nameof(dropInfo));
+            if (items == null) throw new ArgumentNullException(nameof(items));
+            var itemsControl = dropInfo.VisualTarget as ItemsControl;
+            if (itemsControl != null)
+            {
+                var tvItem = dropInfo.VisualTargetItem as TreeViewItem;
+                var tvItemIsExpanded = tvItem != null && tvItem.HasHeader && tvItem.HasItems && tvItem.IsExpanded;
+
+                var itemsParent = tvItemIsExpanded ? tvItem : (dropInfo.VisualTargetItem != null ? ItemsControl.ItemsControlFromItemContainer(dropInfo.VisualTargetItem) : itemsControl);
+                itemsParent = itemsParent ?? itemsControl;
+
+                itemsParent.ClearSelectedItems();
+
+                foreach (var obj in items)
+                {
+                    if (applyTemplate)
+                    {
+                        // call ApplyTemplate for TabItem in TabControl to avoid this error:
+                        //
+                        // System.Windows.Data Error: 4 : Cannot find source for binding with reference
+                        var container = itemsParent.ItemContainerGenerator.ContainerFromItem(obj) as FrameworkElement;
+                        container?.ApplyTemplate();
+                    }
+                    itemsParent.SetItemSelected(obj, true);
+                }
+
+                if (focusVisualTarget)
+                {
+                    itemsControl.Focus();
+                }
+            }
+        }
+
         /// <summary>
         /// Determines whether the data of the drag drop action should be copied otherwise moved.
         /// </summary>
@@ -133,87 +240,11 @@ namespace GongSolutions.Wpf.DragDrop
                     destinationList.Insert(insertIndex++, obj2Insert);
                 }
 
-                if (itemsControl != null)
+                var selectDroppedItems = itemsControl is TabControl || (itemsControl != null && DragDrop.GetSelectDroppedItems(itemsControl));
+                if (selectDroppedItems)
                 {
-                    var itemsParent = (dropInfo.VisualTargetItem != null ? ItemsControl.ItemsControlFromItemContainer(dropInfo.VisualTargetItem) : itemsControl) ?? itemsControl;
-                    var keepSelection = itemsControl is TabControl || true;
-                    if (keepSelection)
-                    {
-                        itemsParent.ClearSelectedItems();
-                        foreach (var obj in objects2Insert)
-                        {
-                            // call ApplyTemplate for TabItem in TabControl to avoid this error:
-                            //
-                            // System.Windows.Data Error: 4 : Cannot find source for binding with reference
-                            var container = itemsParent.ItemContainerGenerator.ContainerFromItem(obj) as FrameworkElement;
-                            container?.ApplyTemplate();
-                            itemsParent.SetItemSelected(obj, true);
-                        }
-                    }
-                    itemsControl.Focus();
+                    SelectDroppedItems(dropInfo, objects2Insert);
                 }
-            }
-        }
-
-        /// <summary>
-        /// Test the specified drop information for the right data.
-        /// </summary>
-        /// <param name="dropInfo">The drop information.</param>
-        public static bool CanAcceptData(IDropInfo dropInfo)
-        {
-            if (dropInfo == null || dropInfo.DragInfo == null)
-            {
-                return false;
-            }
-
-            if (!dropInfo.IsSameDragDropContextAsSource)
-            {
-                return false;
-            }
-
-            // do not drop on itself
-            var isTreeViewItem = dropInfo.InsertPosition.HasFlag(RelativeInsertPosition.TargetItemCenter)
-                                 && dropInfo.VisualTargetItem is TreeViewItem;
-            if (isTreeViewItem && dropInfo.VisualTargetItem == dropInfo.DragInfo.VisualSourceItem)
-            {
-                return false;
-            }
-
-            if (dropInfo.DragInfo.SourceCollection == dropInfo.TargetCollection)
-            {
-                var targetList = dropInfo.TargetCollection.TryGetList();
-                return targetList != null;
-            }
-            //      else if (dropInfo.DragInfo.SourceCollection is ItemCollection) {
-            //        return false;
-            //      }
-            else if (dropInfo.TargetCollection == null)
-            {
-                return false;
-            }
-            else
-            {
-                if (TestCompatibleTypes(dropInfo.TargetCollection, dropInfo.Data))
-                {
-                    var isChildOf = IsChildOf(dropInfo.VisualTargetItem, dropInfo.DragInfo.VisualSourceItem);
-                    return !isChildOf;
-                }
-                else
-                {
-                    return false;
-                }
-            }
-        }
-
-        public static IEnumerable ExtractData(object data)
-        {
-            if (data is IEnumerable && !(data is string))
-            {
-                return (IEnumerable)data;
-            }
-            else
-            {
-                return Enumerable.Repeat(data, 1);
             }
         }
 

--- a/src/GongSolutions.WPF.DragDrop.Shared/DefaultDropHandler.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DefaultDropHandler.cs
@@ -113,11 +113,10 @@ namespace GongSolutions.Wpf.DragDrop
 
             if (destinationList != null)
             {
-                var tabControl = dropInfo.VisualTarget as TabControl;
+                var objects2Insert = new List<object>();
 
                 // check for cloning
-                var cloneData = dropInfo.Effects.HasFlag(DragDropEffects.Copy)
-                                || dropInfo.Effects.HasFlag(DragDropEffects.Link);
+                var cloneData = dropInfo.Effects.HasFlag(DragDropEffects.Copy) || dropInfo.Effects.HasFlag(DragDropEffects.Link);
                 foreach (var o in data)
                 {
                     var obj2Insert = o;
@@ -130,22 +129,28 @@ namespace GongSolutions.Wpf.DragDrop
                         }
                     }
 
+                    objects2Insert.Add(obj2Insert);
                     destinationList.Insert(insertIndex++, obj2Insert);
+                }
 
-                    if (tabControl != null)
+                if (itemsControl != null)
+                {
+                    var itemsParent = (dropInfo.VisualTargetItem != null ? ItemsControl.ItemsControlFromItemContainer(dropInfo.VisualTargetItem) : itemsControl) ?? itemsControl;
+                    var keepSelection = itemsControl is TabControl || true;
+                    if (keepSelection)
                     {
-                        // call ApplyTemplate for TabItem in TabControl to avoid this error:
-                        //
-                        // System.Windows.Data Error: 4 : Cannot find source for binding with reference
-                        // 'RelativeSource FindAncestor, AncestorType='System.Windows.Controls.TabControl', AncestorLevel='1''.
-                        // BindingExpression:Path=TabStripPlacement; DataItem=null; target element is 'TabItem' (Name='');
-                        // target property is 'NoTarget' (type 'Object')
-                        var container = tabControl.ItemContainerGenerator.ContainerFromItem(obj2Insert) as TabItem;
-                        container?.ApplyTemplate();
-
-                        // for better experience: select the dragged TabItem
-                        tabControl.SetSelectedItem(obj2Insert);
+                        itemsParent.ClearSelectedItems();
+                        foreach (var obj in objects2Insert)
+                        {
+                            // call ApplyTemplate for TabItem in TabControl to avoid this error:
+                            //
+                            // System.Windows.Data Error: 4 : Cannot find source for binding with reference
+                            var container = itemsParent.ItemContainerGenerator.ContainerFromItem(obj) as FrameworkElement;
+                            container?.ApplyTemplate();
+                            itemsParent.SetItemSelected(obj, true);
+                        }
                     }
+                    itemsControl.Focus();
                 }
             }
         }

--- a/src/GongSolutions.WPF.DragDrop.Shared/DragDrop.Properties.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DragDrop.Properties.cs
@@ -893,5 +893,31 @@ namespace GongSolutions.Wpf.DragDrop
         {
             source.SetValue(MinimumVerticalDragDistanceProperty, value);
         }
+
+        /// <summary>
+        /// Gets or sets whether if the dropped items should be select again (should keep the selection).
+        /// Default is false.
+        /// </summary>
+        public static readonly DependencyProperty SelectDroppedItemsProperty
+            = DependencyProperty.RegisterAttached("SelectDroppedItems",
+                                                  typeof(bool),
+                                                  typeof(DragDrop),
+                                                  new PropertyMetadata(false));
+
+        /// <summary>
+        /// Gets whether if the dropped items should be select again (should keep the selection).
+        /// </summary>
+        public static bool GetSelectDroppedItems(UIElement target)
+        {
+            return (bool)target.GetValue(SelectDroppedItemsProperty);
+        }
+
+        /// <summary>
+        /// Sets whether if the dropped items should be select again (should keep the selection).
+        /// </summary>
+        public static void SetSelectDroppedItems(UIElement target, bool value)
+        {
+            target.SetValue(SelectDroppedItemsProperty, value);
+        }
     }
 }

--- a/src/GongSolutions.WPF.DragDrop.Shared/Utilities/ItemsControlExtensions.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/Utilities/ItemsControlExtensions.cs
@@ -330,6 +330,30 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
                     ((ListBox)itemsControl).SelectionMode = selectionMode;
                 }
             }
+            else if (itemsControl is TreeViewItem)
+            {
+                // clear old selected item
+                var treeView = ItemsControl.ItemsControlFromItemContainer((TreeViewItem)itemsControl);
+                if (treeView != null)
+                {
+                    var prevSelectedItem = treeView.GetValue(TreeView.SelectedItemProperty);
+                    if (prevSelectedItem != null)
+                    {
+                        var prevSelectedTreeViewItem = treeView.ItemContainerGenerator.ContainerFromItem(prevSelectedItem) as TreeViewItem;
+                        if (prevSelectedTreeViewItem != null)
+                        {
+                            prevSelectedTreeViewItem.IsSelected = false;
+                        }
+                    }
+                }
+                // set new selected item
+                // TreeView.SelectedItemProperty is a read only property, so we must set the selection on the TreeViewItem itself
+                var treeViewItem = ((TreeViewItem)itemsControl).ItemContainerGenerator.ContainerFromItem(item) as TreeViewItem;
+                if (treeViewItem != null)
+                {
+                    treeViewItem.IsSelected = true;
+                }
+            }
             else if (itemsControl is TreeView)
             {
                 // clear old selected item
@@ -354,6 +378,45 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
             {
                 ((Selector)itemsControl).SelectedItem = null;
                 ((Selector)itemsControl).SelectedItem = item;
+            }
+        }
+
+        public static void ClearSelectedItems(this ItemsControl itemsControl)
+        {
+            if (itemsControl is MultiSelector)
+            {
+                if (((MultiSelector)itemsControl).CanSelectMultipleItems())
+                {
+                    ((MultiSelector)itemsControl).SelectedItems.Clear();
+                }
+                ((MultiSelector)itemsControl).SelectedItem = null;
+            }
+            else if (itemsControl is ListBox)
+            {
+                ((ListBox)itemsControl).SelectedItems.Clear();
+                ((ListBox)itemsControl).SelectedItem = null;
+            }
+            else if (itemsControl is TreeViewItem)
+            {
+                var treeView = ItemsControl.ItemsControlFromItemContainer((TreeViewItem)itemsControl);
+                treeView?.ClearSelectedItems();
+            }
+            else if (itemsControl is TreeView)
+            {
+                // clear old selected item
+                var prevSelectedItem = ((TreeView)itemsControl).GetValue(TreeView.SelectedItemProperty);
+                if (prevSelectedItem != null)
+                {
+                    var prevSelectedTreeViewItem = ((TreeView)itemsControl).ItemContainerGenerator.ContainerFromItem(prevSelectedItem) as TreeViewItem;
+                    if (prevSelectedTreeViewItem != null)
+                    {
+                        prevSelectedTreeViewItem.IsSelected = false;
+                    }
+                }
+            }
+            else if (itemsControl is Selector)
+            {
+                ((Selector)itemsControl).SelectedItem = null;
             }
         }
 
@@ -438,51 +501,59 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
             }
         }
 
-        public static void SetItemSelected(this ItemsControl itemsControl, object item, bool value)
+        public static void SetItemSelected(this ItemsControl itemsControl, object item, bool itemSelected)
         {
             if (itemsControl is MultiSelector)
             {
                 var multiSelector = (MultiSelector)itemsControl;
 
-                if (value)
+                if (multiSelector.CanSelectMultipleItems())
                 {
-                    if (multiSelector.CanSelectMultipleItems())
+                    if (itemSelected)
                     {
                         multiSelector.SelectedItems.Add(item);
                     }
                     else
                     {
-                        multiSelector.SelectedItem = item;
+                        multiSelector.SelectedItems.Remove(item);
                     }
                 }
                 else
                 {
-                    multiSelector.SelectedItems.Remove(item);
+                    multiSelector.SelectedItem = null;
+                    if (itemSelected)
+                    {
+                        multiSelector.SelectedItem = item;
+                    }
                 }
             }
             else if (itemsControl is ListBox)
             {
                 var listBox = (ListBox)itemsControl;
 
-                if (value)
+                if (listBox.SelectionMode != SelectionMode.Single)
                 {
-                    if (listBox.SelectionMode != SelectionMode.Single)
+                    if (itemSelected)
                     {
                         listBox.SelectedItems.Add(item);
                     }
                     else
                     {
-                        listBox.SelectedItem = item;
+                        listBox.SelectedItems.Remove(item);
                     }
                 }
                 else
                 {
-                    listBox.SelectedItems.Remove(item);
+                    listBox.SelectedItem = null;
+                    if (itemSelected)
+                    {
+                        listBox.SelectedItem = item;
+                    }
                 }
             }
             else
             {
-                if (value)
+                if (itemSelected)
                 {
                     itemsControl.SetSelectedItem(item);
                 }

--- a/src/GongSolutions.WPF.DragDrop.Shared/Utilities/ItemsControlExtensions.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/Utilities/ItemsControlExtensions.cs
@@ -381,6 +381,10 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
             }
         }
 
+        /// <summary>
+        /// Clears the selected items.
+        /// </summary>
+        /// <param name="itemsControl">The items control.</param>
         public static void ClearSelectedItems(this ItemsControl itemsControl)
         {
             if (itemsControl is MultiSelector)

--- a/src/Showcase.WPF.DragDrop.NET45/Views/MixedSamples.xaml
+++ b/src/Showcase.WPF.DragDrop.NET45/Views/MixedSamples.xaml
@@ -507,6 +507,78 @@
                 </DockPanel>
             </TabItem>
 
+            <TabItem Header="Keep Selection">
+                <TabItem.Resources />
+                <DockPanel LastChildFill="True">
+                    <StackPanel DockPanel.Dock="Top" Orientation="Vertical">
+                        <TextBlock Style="{StaticResource SampleHeaderTextBlockStyle}" Text="Keep selection after Drag and drop action." />
+                    </StackPanel>
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+
+                        <Grid Grid.Row="0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <ListBox x:Name="LeftBoundKeepSelListBox"
+                                     Grid.Column="0"
+                                     Height="Auto"
+                                     dd:DragDrop.DropTargetAdornerBrush="Crimson"
+                                     dd:DragDrop.IsDragSource="True"
+                                     dd:DragDrop.IsDropTarget="True"
+                                     dd:DragDrop.SelectDroppedItems="True"
+                                     dd:DragDrop.ShowAlwaysDropTargetAdorner="True"
+                                     dd:DragDrop.UseDefaultEffectDataTemplate="True"
+                                     ItemsSource="{Binding Data.Collection1}" />
+                            <ListView Grid.Column="1"
+                                      Height="Auto"
+                                      dd:DragDrop.DropTargetAdornerBrush="Crimson"
+                                      dd:DragDrop.IsDragSource="True"
+                                      dd:DragDrop.IsDropTarget="True"
+                                      dd:DragDrop.SelectDroppedItems="True"
+                                      dd:DragDrop.ShowAlwaysDropTargetAdorner="True"
+                                      dd:DragDrop.UseDefaultEffectDataTemplate="True"
+                                      ItemsSource="{Binding Data.Collection2}">
+                                <ListView.ItemTemplate>
+                                    <DataTemplate>
+                                        <DockPanel LastChildFill="True">
+                                            <iconPacks:PackIconMaterial Margin="2"
+                                                                        Focusable="False"
+                                                                        Foreground="DarkOrange"
+                                                                        Kind="CheckboxMarkedOutline" />
+                                            <TextBlock Margin="2" Text="{Binding}" />
+                                        </DockPanel>
+                                    </DataTemplate>
+                                </ListView.ItemTemplate>
+                            </ListView>
+                        </Grid>
+
+                        <StackPanel Grid.Row="1">
+                            <TextBlock Style="{StaticResource DefaultTextBlockStyle}" Text="Customization (for left ListBox)" />
+                            <CheckBox Margin="10 5"
+                                      Content="IsDragSource"
+                                      IsChecked="{Binding ElementName=LeftBoundKeepSelListBox, Path=(dd:DragDrop.IsDragSource), Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <CheckBox Margin="10 5"
+                                      Content="UseDefaultDragAdorner"
+                                      IsChecked="{Binding ElementName=LeftBoundKeepSelListBox, Path=(dd:DragDrop.UseDefaultDragAdorner), Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <CheckBox Margin="10 5"
+                                      Content="UseDefaultEffectDataTemplate"
+                                      IsChecked="{Binding ElementName=LeftBoundKeepSelListBox, Path=(dd:DragDrop.UseDefaultEffectDataTemplate), Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <CheckBox Margin="10 5"
+                                      Content="ShowAlwaysDropTargetAdorner"
+                                      IsChecked="{Binding ElementName=LeftBoundKeepSelListBox, Path=(dd:DragDrop.ShowAlwaysDropTargetAdorner), Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <CheckBox Margin="10 5"
+                                      Content="SelectDroppedItems"
+                                      IsChecked="{Binding ElementName=LeftBoundKeepSelListBox, Path=(dd:DragDrop.SelectDroppedItems), Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        </StackPanel>
+                    </Grid>
+                </DockPanel>
+            </TabItem>
+
         </TabControl>
 
     </Grid>


### PR DESCRIPTION
- New attached property `SelectDroppedItems`. If this is set to true all dropped items will be selected again after drag&drop action (by using the default drop handler).
- New static method `SelectDroppedItems` which can be used together with a drop info and the items which are should be selected.
- New static method `ClearSelectedItems` for `ItemsControl`

![gong_dragdrop_keep_selection2](https://user-images.githubusercontent.com/658431/32894912-90a12a02-cade-11e7-956d-e31502562814.gif)

Closes #176 
Relates to #176 