### PR TITLE
Fix DropTargetInsertionAdorner for empty DataGrid and ListView

### DIFF
--- a/src/GongSolutions.WPF.DragDrop.Shared/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DragDrop.cs
@@ -620,7 +620,7 @@ namespace GongSolutions.Wpf.DragDrop
                 {
                     adornedElement = itemsControl.GetVisualDescendent<TabPanel>();
                 }
-                else if (itemsControl is DataGrid)
+                else if (itemsControl is DataGrid || (itemsControl as ListView)?.View is GridView)
                 {
                     adornedElement = itemsControl.GetVisualDescendent<ScrollContentPresenter>() as UIElement ?? itemsControl.GetVisualDescendent<ItemsPresenter>() as UIElement ?? itemsControl;
                 }

--- a/src/GongSolutions.WPF.DragDrop.Shared/DropTargetInsertionAdorner.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DropTargetInsertionAdorner.cs
@@ -2,8 +2,12 @@
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Controls;
-#if NET35
 using GongSolutions.Wpf.DragDrop.Utilities;
+#if NET35
+using Microsoft.Windows.Controls;
+using Microsoft.Windows.Controls.Primitives;
+#else
+using System.Windows.Controls.Primitives;
 #endif
 
 namespace GongSolutions.Wpf.DragDrop
@@ -98,6 +102,22 @@ namespace GongSolutions.Wpf.DragDrop
                             }
                             else
                             {
+                                if ((itemsControl as ListView)?.View is GridView)
+                                {
+                                    var header = itemsControl.GetVisualDescendent<GridViewHeaderRowPresenter>();
+                                    if (header != null)
+                                    {
+                                        itemRect.Y += header.RenderSize.Height;
+                                    }
+                                }
+                                else if (itemsControl is DataGrid)
+                                {
+                                    var header = itemsControl.GetVisualDescendent<DataGridColumnHeadersPresenter>();
+                                    if (header != null)
+                                    {
+                                        itemRect.Y += header.RenderSize.Height;
+                                    }
+                                }
                                 itemRect.Y += this.Pen.Thickness;
                             }
                         }

--- a/src/Showcase.WPF.DragDrop.NET45/Views/DataGridSamples.xaml
+++ b/src/Showcase.WPF.DragDrop.NET45/Views/DataGridSamples.xaml
@@ -31,6 +31,7 @@
                                   dd:DragDrop.DropScrollingMode="VerticalOnly"
                                   dd:DragDrop.IsDragSource="True"
                                   dd:DragDrop.IsDropTarget="True"
+                                  dd:DragDrop.ShowAlwaysDropTargetAdorner="True"
                                   dd:DragDrop.UseDefaultEffectDataTemplate="True"
                                   CanUserAddRows="False"
                                   CanUserDeleteRows="False"

--- a/src/Showcase.WPF.DragDrop.NET45/Views/ListViewSamples.xaml
+++ b/src/Showcase.WPF.DragDrop.NET45/Views/ListViewSamples.xaml
@@ -34,6 +34,7 @@
                                           Grid.Column="0"
                                           dd:DragDrop.IsDragSource="True"
                                           dd:DragDrop.IsDropTarget="True"
+                                          dd:DragDrop.ShowAlwaysDropTargetAdorner="True"
                                           ItemsSource="{Binding Data.Collection1}">
                                     <ListView.View>
                                         <GridView>
@@ -67,6 +68,7 @@
                                 <ListView Grid.Column="1"
                                           dd:DragDrop.IsDragSource="True"
                                           dd:DragDrop.IsDropTarget="True"
+                                          dd:DragDrop.ShowAlwaysDropTargetAdorner="True"
                                           dd:DragDrop.UseDefaultDragAdorner="True"
                                           ItemsSource="{Binding Data.Collection2}">
                                     <ListView.ItemTemplate>


### PR DESCRIPTION
## What changed?

The insertion adorner was painted at wrong position. Now the adorner tries to get the header and calculates the right position for the adorner.
