### PR TITLE
Nested list view drop target

### DIFF
--- a/src/GongSolutions.WPF.DragDrop.Shared/DropInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DropInfo.cs
@@ -99,7 +99,7 @@ namespace GongSolutions.Wpf.DragDrop
                 {
                     // ok, no item found, so maybe we can found an item at top, left, right or bottom
                     item = itemsControl.GetItemContainerAt(this.DropPosition, this.VisualTargetOrientation);
-                    directlyOverItem = item != null && VisualTreeHelper.GetDescendantBounds(item).Contains(this.DropPosition);
+                    directlyOverItem = DropPosition.DirectlyOverElement(this.item, itemsControl);
                 }
 
                 if (item == null && this.TargetGroup != null && this.TargetGroup.IsBottomLevel)
@@ -108,7 +108,7 @@ namespace GongSolutions.Wpf.DragDrop
                     if (itemData != null)
                     {
                         item = itemsControl.ItemContainerGenerator.ContainerFromItem(itemData) as UIElement;
-                        directlyOverItem = item != null && VisualTreeHelper.GetDescendantBounds(item).Contains(this.DropPosition);
+                        directlyOverItem = DropPosition.DirectlyOverElement(this.item, itemsControl);
                     }
                 }
 

--- a/src/GongSolutions.WPF.DragDrop.Shared/Utilities/DragDropExtensions.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/Utilities/DragDropExtensions.cs
@@ -33,5 +33,22 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
         {
             return element != null && DragDrop.GetIsDropTarget(element);
         }
+        
+        /// <summary>
+        /// Gets if drop position is directly over element
+        /// </summary>
+        /// <param name="dropPosition">Drop position</param>
+        /// <param name="element">element to check whether or not the drop position is directly over or not</param>
+        /// <param name="relativeToElement">element to which the drop position is related</param>
+        /// <returns>drop position is directly over element or not</returns>
+        public static bool DirectlyOverElement(this Point dropPosition, UIElement element, UIElement relativeToElement)
+        {
+            if (element == null)
+                return false;
+
+            var relativeItemPosition = element.TranslatePoint(new Point(0, 0), relativeToElement);
+            var relativeDropPosition = new Point(dropPosition.X - relativeItemPosition.X, dropPosition.Y - relativeItemPosition.Y);
+            return VisualTreeHelper.GetDescendantBounds(element).Contains(relativeDropPosition); 
+        }
     }
 }

--- a/src/GongSolutions.WPF.DragDrop.Shared/Utilities/DragDropExtensions.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/Utilities/DragDropExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+using System.Windows;
+using System.Windows.Media;
 
 namespace GongSolutions.Wpf.DragDrop.Utilities
 {


### PR DESCRIPTION
see issue #283

DropPosition is relative to parent items control, therefore it needs to be recalculated to be relative to the child item, i.e. the ItemContainer. E.g.:
Outer ListView with 5 rows, each row has a Height of 100, inner ListViews respectively. Lets say DropPosition is on third row of outer ListView, and has coordinates X=50, Y=250. The inner ListView ist under the DropPosition. Now the ItemContainer's Y-Bound is [0, 100], DropPosition's Y-coordinate is 250 => DropPosition is not in the descendant bounds.
Fix: get the ItemContainer's position relative to the Parent's (0,0)-Coordinate an subtract the ItemContainer's relative coordinates from the DropPosition coordinates