### PR TITLE
Make dragInfo available in custom drag adorner template selector

### DIFF
--- a/src/GongSolutions.WPF.DragDrop.Shared/Utilities/DragDropExtensions.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/Utilities/DragDropExtensions.cs
@@ -3,6 +3,10 @@ using System.Windows.Media;
 
 namespace GongSolutions.Wpf.DragDrop.Utilities
 {
+    using System;
+    using System.Windows.Controls;
+    using System.Windows.Media.Imaging;
+
     public static class DragDropExtensions
     {
         /// <summary>
@@ -50,6 +54,74 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
             var relativeItemPosition = element.TranslatePoint(new Point(0, 0), relativeToElement);
             var relativeDropPosition = new Point(dropPosition.X - relativeItemPosition.X, dropPosition.Y - relativeItemPosition.Y);
             return VisualTreeHelper.GetDescendantBounds(element).Contains(relativeDropPosition); 
+        }
+
+        /// <summary>
+        /// Capture screen and create data template containing the captured image
+        /// </summary>
+        /// <param name="element">visual source to capture screen of</param>
+        /// <param name="visualSourceFlowDirection">Flowdirection of visual source</param>
+        /// <returns></returns>
+        public static DataTemplate GetCaptureScreenDataTemplate(this UIElement element, FlowDirection visualSourceFlowDirection)
+        {
+            DataTemplate template = null;
+            var bs = CaptureScreen(element, visualSourceFlowDirection);
+            if (bs != null)
+            {
+                var factory = new FrameworkElementFactory(typeof(Image));
+                factory.SetValue(Image.SourceProperty, bs);
+                factory.SetValue(RenderOptions.EdgeModeProperty, EdgeMode.Aliased);
+                factory.SetValue(RenderOptions.BitmapScalingModeProperty, BitmapScalingMode.HighQuality);
+                factory.SetValue(FrameworkElement.WidthProperty, bs.Width);
+                factory.SetValue(FrameworkElement.HeightProperty, bs.Height);
+                factory.SetValue(FrameworkElement.HorizontalAlignmentProperty, HorizontalAlignment.Left);
+                factory.SetValue(FrameworkElement.VerticalAlignmentProperty, VerticalAlignment.Top);
+                template = new DataTemplate { VisualTree = factory };
+            }
+            return template;
+        }
+
+        // Helper to generate the image - I grabbed this off Google 
+        // somewhere. -- Chris Bordeman cbordeman@gmail.com
+        private static BitmapSource CaptureScreen(Visual target, FlowDirection flowDirection)
+        {
+            if (target == null)
+            {
+                return null;
+            }
+
+            var dpiX = DpiHelper.DpiX;
+            var dpiY = DpiHelper.DpiY;
+
+            var bounds = VisualTreeHelper.GetDescendantBounds(target);
+            var dpiBounds = DpiHelper.LogicalRectToDevice(bounds);
+
+            var pixelWidth = (int)Math.Ceiling(dpiBounds.Width);
+            var pixelHeight = (int)Math.Ceiling(dpiBounds.Height);
+            if (pixelWidth < 0 || pixelHeight < 0)
+            {
+                return null;
+            }
+
+            var rtb = new RenderTargetBitmap(pixelWidth, pixelHeight, dpiX, dpiY, PixelFormats.Pbgra32);
+
+            var dv = new DrawingVisual();
+            using (var ctx = dv.RenderOpen())
+            {
+                var vb = new VisualBrush(target);
+                if (flowDirection == FlowDirection.RightToLeft)
+                {
+                    var transformGroup = new TransformGroup();
+                    transformGroup.Children.Add(new ScaleTransform(-1, 1));
+                    transformGroup.Children.Add(new TranslateTransform(bounds.Size.Width - 1, 0));
+                    ctx.PushTransform(transformGroup);
+                }
+                ctx.DrawRectangle(vb, null, new Rect(new Point(), bounds.Size));
+            }
+
+            rtb.Render(dv);
+
+            return rtb;
         }
     }
 }


### PR DESCRIPTION
DragInfo useful in custom drag adorner template selectors for accessing visual tree. E.g.: in nested ListBox scenario, if dragging an item of inner ListBox onto outer ListBox, it could be that not only the selected item should be moved but the whole group. The drag adorner should not only show the screen capture of the selected item but the screen capture of its parent, the whole ListBox. Therefore the capture screen data template creation functionality is moved to DragDropExtensions.
