### PR TITLE
Allow DataObject to be any object

### DIFF
--- a/src/GongSolutions.WPF.DragDrop.Shared/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DragDrop.cs
@@ -9,6 +9,7 @@ using System.Windows.Media;
 using GongSolutions.Wpf.DragDrop.Icons;
 using GongSolutions.Wpf.DragDrop.Utilities;
 using System.Windows.Media.Imaging;
+using IComDataObject = System.Runtime.InteropServices.ComTypes.IDataObject;
 #if NET35
 using Microsoft.Windows.Controls;
 #endif
@@ -498,7 +499,14 @@ namespace GongSolutions.Wpf.DragDrop
                             try
                             {
                                 m_DragInProgress = true;
-                                var dragDropEffects = System.Windows.DragDrop.DoDragDrop(dragInfo.VisualSource, dataObject, dragInfo.Effects);
+                                DragDropEffects dragDropEffects;
+
+                                var comDataObject = dataObject as IComDataObject;
+                                if (comDataObject != null && dragInfo.CustomComDataObjectHandler != null)
+                                    dragDropEffects = dragInfo.CustomComDataObjectHandler(dragInfo.VisualSource, comDataObject, dragInfo.Effects);
+                                else
+                                    dragDropEffects = System.Windows.DragDrop.DoDragDrop(dragInfo.VisualSource, dataObject, dragInfo.Effects);
+
                                 if (dragDropEffects == DragDropEffects.None)
                                 {
                                     dragHandler.DragCancelled();

--- a/src/GongSolutions.WPF.DragDrop.Shared/DragInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DragInfo.cs
@@ -1,10 +1,12 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
 using GongSolutions.Wpf.DragDrop.Utilities;
+using IComDataObject = System.Runtime.InteropServices.ComTypes.IDataObject;
 
 namespace GongSolutions.Wpf.DragDrop
 {
@@ -271,7 +273,12 @@ namespace GongSolutions.Wpf.DragDrop
         /// Gets the <see cref="IDataObject"/> which is used by the drag and drop operation. Set it to
         /// a custom instance if custom drag and drop behavior is needed.
         /// </summary>
-        public IDataObject DataObject { get; set; }
+        public object DataObject { get; set; }
+
+        /// <summary>
+        /// Gets the custom function to enter drag drop operations. Set it to an instance if custom drag and drop behavior is needed.
+        /// </summary>
+        public Func<DependencyObject, IComDataObject, DragDropEffects, DragDropEffects> CustomComDataObjectHandler { get; set; }
 
         /// <summary>
         /// Gets the drag drop copy key state indicating the effect of the drag drop operation.

--- a/src/GongSolutions.WPF.DragDrop.Shared/DropInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DropInfo.cs
@@ -5,7 +5,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Data;
-using System.Windows.Media;
 using GongSolutions.Wpf.DragDrop.Utilities;
 using JetBrains.Annotations;
 

--- a/src/GongSolutions.WPF.DragDrop.Shared/IDragInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/IDragInfo.cs
@@ -1,7 +1,9 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Windows;
 using System.Windows.Data;
 using System.Windows.Input;
+using IComDataObject = System.Runtime.InteropServices.ComTypes.IDataObject;
 
 namespace GongSolutions.Wpf.DragDrop
 {
@@ -106,10 +108,15 @@ namespace GongSolutions.Wpf.DragDrop
         FlowDirection VisualSourceFlowDirection { get; }
 
         /// <summary>
-        /// Gets the <see cref="IDataObject"/> which is used by the drag and drop operation. Set it to
+        /// Gets the DataObject which is used by the drag and drop operation. Set it to
         /// a custom instance if custom drag and drop behavior is needed.
         /// </summary>
-        IDataObject DataObject { get; set; }
+        object DataObject { get; set; }
+
+        /// <summary>
+        /// Gets the custom function to enter drag drop operations. Set it to an instance if custom drag and drop behavior is needed.
+        /// </summary>
+        Func<DependencyObject, IComDataObject, DragDropEffects, DragDropEffects> CustomComDataObjectHandler { get; set; }
 
         /// <summary>
         /// Gets the drag drop copy key state indicating the effect of the drag drop operation.


### PR DESCRIPTION
## What changed?

The DataObject implementation of the WPF is limited in several ways. For example it is not possible to asynchronously drag and drop to other process windows. It is possible to fix this by implementing your own version of IDataObject (the com interface, not the WPF interface). There is a create article describing just this here: https://dlaa.me/blog/post/9913083

However it is not possible to use this own implementation with this library. My changes enable you to use the library with any implementation.
