### PR TITLE
Added LambdaDragHandler and -DropHandler

### DIFF
--- a/src/GongSolutions.WPF.DragDrop.Shared/GongSolutions.WPF.DragDrop.Shared.projitems
+++ b/src/GongSolutions.WPF.DragDrop.Shared/GongSolutions.WPF.DragDrop.Shared.projitems
@@ -28,6 +28,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)IDragSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IDropInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IDropTarget.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)LambdaDragHandler.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)LambdaDropHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollingMode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\DpiHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\DragDropExtensions.cs" />

--- a/src/GongSolutions.WPF.DragDrop.Shared/LambdaDragHandler.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/LambdaDragHandler.cs
@@ -1,0 +1,102 @@
+﻿namespace GongSolutions.WPF.DragDrop.Shared
+{
+    using System;
+    using System.Windows;
+    using GongSolutions.Wpf.DragDrop;
+
+    /// <summary>
+    /// This static class provides a factory method <see cref="Create"/> for creating stateless instances of <see cref="IDragSource"/> using <see cref="Action"/>s, <see cref="Action{T}"/>s, <see cref="Action{T1, T2}"/>s and <see cref="Func{T,TResult}"/>s.
+    /// That way it isn't required to implement a whole class.
+    /// </summary>
+    public static class LambdaDragHandler
+    {
+        /// <summary>
+        /// Creates an instance of <see cref="IDragSource"/> using the given <see cref="Action"/>s, <see cref="Action{T}"/>s, <see cref="Action{T1, T2}"/>s and <see cref="Func{T,TResult}"/>s as internal implementation.
+        /// </summary>
+        /// <param name="startDrag">The returned instance of <see cref="IDragSource"/> will use this <see cref="Action{T}"/> as inner implementation for the <see cref="IDragSource.StartDrag"/> method.
+        /// If this parameter is null nothing will happen on the <see cref="IDragSource.StartDrag"/> call.</param>
+        /// <param name="canStartDrag">The returned instance of <see cref="IDragSource"/> will use this <see cref="Func{T,TResult}"/> as inner implementation for the <see cref="IDragSource.CanStartDrag"/> function.
+        /// If this parameter is null the function will always return true.</param>
+        /// <param name="dropped">The returned instance of <see cref="IDragSource"/> will use this <see cref="Action{T}"/> as inner implementation for the <see cref="IDragSource.Dropped"/> method.
+        /// If this parameter is null nothing will happen on the <see cref="IDragSource.StartDrag"/> call.</param>
+        /// <param name="dragDropOperationFinished">The returned instance of <see cref="IDragSource"/> will use this <see cref="Action{T1, T2}"/> as inner implementation for the <see cref="IDragSource.DragDropOperationFinished"/> method.
+        /// If this parameter is null nothing will happen on the <see cref="IDragSource.DragDropOperationFinished"/> call.</param>
+        /// <param name="dragCanceled">The returned instance of <see cref="IDragSource"/> will use this <see cref="Action"/> as inner implementation for the <see cref="IDragSource.DragCancelled"/> method.
+        /// If this parameter is null nothing will happen on the <see cref="IDragSource.DragCancelled"/> call.</param>
+        /// <param name="tryCatchOccurredException">The returned instance of <see cref="IDragSource"/> will use this <see cref="Func{T,TResult}"/> as inner implementation for the <see cref="IDragSource.TryCatchOccurredException"/> function.
+        /// If this parameter is null the function will always return false.</param>
+        /// <returns>An instance of <see cref="IDropTarget"/> using the given <see cref="Action{T}"/>s, <see cref="Action{T1, T2}"/>s and <see cref="Func{T,TResult}"/>s as internal implementation.</returns>
+        public static IDragSource Create(
+            Action<IDragInfo> startDrag = null,
+            Func<IDragInfo, bool> canStartDrag = null,
+            Action<IDropInfo> dropped = null,
+            Action<DragDropEffects, IDragInfo> dragDropOperationFinished = null,
+            Action dragCanceled = null,
+            Func<Exception, bool> tryCatchOccurredException = null)
+        {
+            return new LambdaDragHandlerInner(
+                startDrag, 
+                canStartDrag, 
+                dropped, 
+                dragDropOperationFinished, 
+                dragCanceled, 
+                tryCatchOccurredException);
+        }
+
+        private class LambdaDragHandlerInner : IDragSource
+        {
+            private readonly Action<IDragInfo> startDrag;
+            private readonly Func<IDragInfo, bool> canStartDrag;
+            private readonly Action<IDropInfo> dropped;
+            private readonly Action<DragDropEffects, IDragInfo> dragDropOperationFinished;
+            private readonly Action dragCanceled;
+            private readonly Func<Exception, bool> tryCatchOccurredException;
+
+            public LambdaDragHandlerInner(
+                Action<IDragInfo> startDrag = null,
+                Func<IDragInfo, bool> canStartDrag = null,
+                Action<IDropInfo> dropped = null,
+                Action<DragDropEffects, IDragInfo> dragDropOperationFinished = null,
+                Action dragCanceled = null,
+                Func<Exception, bool> tryCatchOccurredException = null)
+            {
+                this.startDrag = startDrag;
+                this.canStartDrag = canStartDrag;
+                this.dropped = dropped;
+                this.dragDropOperationFinished = dragDropOperationFinished;
+                this.dragCanceled = dragCanceled;
+                this.tryCatchOccurredException = tryCatchOccurredException;
+            }
+
+            public void StartDrag(IDragInfo dragInfo)
+            {
+                this.startDrag?.Invoke(dragInfo);
+            }
+
+            public bool CanStartDrag(IDragInfo dragInfo)
+            {
+                return this.canStartDrag?.Invoke(dragInfo) ?? true;
+            }
+
+            public void Dropped(IDropInfo dropInfo)
+            {
+                this.dropped?.Invoke(dropInfo);
+            }
+
+            public void DragDropOperationFinished(DragDropEffects operationResult, IDragInfo dragInfo)
+            {
+                this.dragDropOperationFinished?.Invoke(operationResult, dragInfo);
+            }
+
+            public void DragCancelled()
+            {
+                this.dragCanceled?.Invoke();
+            }
+
+            public bool TryCatchOccurredException(Exception exception)
+            {
+                return this.tryCatchOccurredException?.Invoke(exception) ?? false;
+            }
+        }
+    }
+}

--- a/src/GongSolutions.WPF.DragDrop.Shared/LambdaDropHandler.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/LambdaDropHandler.cs
@@ -1,0 +1,47 @@
+﻿namespace GongSolutions.WPF.DragDrop.Shared
+{
+    using System;
+    using GongSolutions.Wpf.DragDrop;
+
+    /// <summary>
+    /// This static class provides a factory method <see cref="Create"/> for creating stateless instances of <see cref="IDropTarget"/> using <see cref="Action{T}"/>s.
+    /// That way it isn't required to implement a whole class.
+    /// </summary>
+    public static class LambdaDropHandler
+    {
+        /// <summary>
+        /// Creates an instance of <see cref="IDropTarget"/> using the given <see cref="Action{T}"/>s as internal implementation.
+        /// </summary>
+        /// <param name="dragOver">The returned instance of <see cref="IDropTarget"/> will use this <see cref="Action{T}"/> as inner implementation for the <see cref="IDropTarget.DragOver"/> method.
+        /// If this parameter is null nothing will happen on the <see cref="IDropTarget.DragOver"/> call.</param>
+        /// <param name="drop">The returned instance of <see cref="IDropTarget"/> will use this <see cref="Action{T}"/> as inner implementation for the <see cref="IDropTarget.Drop"/> method.
+        /// If this parameter is null nothing will happen on the <see cref="IDropTarget.Drop"/> call.</param>
+        /// <returns>An instance of <see cref="IDropTarget"/> using the given Actions as internal implementation.</returns>
+        public static IDropTarget Create(Action<IDropInfo> dragOver = null, Action<IDropInfo> drop = null)
+        {
+            return new LambdaDropHandlerInner(dragOver, drop);
+        }
+        
+        private class LambdaDropHandlerInner : IDropTarget
+        {
+            private readonly Action<IDropInfo> dragOver;
+            private readonly Action<IDropInfo> drop;
+
+            public LambdaDropHandlerInner(Action<IDropInfo> dragOver = null, Action<IDropInfo> drop = null)
+            {
+                this.dragOver = dragOver;
+                this.drop = drop;
+            }
+
+            public void DragOver(IDropInfo dropInfo)
+            {
+                this.dragOver?.Invoke(dropInfo);
+            }
+
+            public void Drop(IDropInfo dropInfo)
+            {
+                this.drop?.Invoke(dropInfo);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What changed?

Similar to the IValueConverters in the [LambdaConverter-project](https://github.com/michael-damatov/lambda-converters) the DropHandlers (IDropTarget) and the DragHandlers (IDragSource) could be implemented more conveniently with the "Lambda"-pattern.

Instead of writing a whole class the LambdaHandlers let you implement a handler by passing appropriate Actions and Funcs. All Action- and Func-parameters are optional, hence in cases where a function would be left empty in the implementation, the parameter can just be left out. If assigned to static fields or properties the LamdaHandlers can be referenced via x:Static in Xaml-code. All in all the LambdaHandlers make the implementations of IDropTarget and IDragSource shorter and more convenient to use.
