### PR TITLE
DropTargetInsertionAdorner  is short

### DIFF
--- a/src/GongSolutions.WPF.DragDrop.Shared/DropTargetInsertionAdorner.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DropTargetInsertionAdorner.cs
@@ -89,8 +89,17 @@ namespace GongSolutions.Wpf.DragDrop
                           point2;
                     double rotation = 0;
 
-                    var viewportWidth = DropInfo.TargetScrollViewer?.ViewportWidth ?? double.MaxValue;
-                    var viewportHeight = DropInfo.TargetScrollViewer?.ViewportHeight ?? double.MaxValue;
+                    var viewportWidth = double.MaxValue;
+                    var viewportHeight = double.MaxValue;
+                    if( DropInfo.TargetScrollViewer != null ) {
+                        if( DropInfo.TargetScrollViewer.ScrollableWidth != 0 ) {
+                            viewportWidth = DropInfo.TargetScrollViewer.ViewportWidth;
+                        }
+
+                        if( DropInfo.TargetScrollViewer.ScrollableHeight != 0 ) {
+                            viewportHeight = DropInfo.TargetScrollViewer.ViewportHeight;
+                        }
+                    }
 
                     if (dropInfo.VisualTargetOrientation == Orientation.Vertical)
                     {

--- a/src/GongSolutions.WPF.DragDrop.Shared/Utilities/ItemsControlExtensions.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/Utilities/ItemsControlExtensions.cs
@@ -397,8 +397,11 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
             }
             else if (itemsControl is ListBox)
             {
-                ((ListBox)itemsControl).SelectedItems.Clear();
-                ((ListBox)itemsControl).SelectedItem = null;
+                if (((ListBox)itemsControl).CanSelectMultipleItems())
+                {
+                    ((ListBox)itemsControl).SelectedItems.Clear();
+                    ((ListBox)itemsControl).SelectedItem = null;
+                }
             }
             else if (itemsControl is TreeViewItem)
             {


### PR DESCRIPTION
ViewportWidth is not sometimes right at the time of non-indication ScrollBar

DropTargetInsertionAdorner  is short

> Sample
```
<Grid Width="500">
    <Grid.ColumnDefinitions>
        <ColumnDefinition Width="Auto" />
    </Grid.ColumnDefinitions>

    <ListView MinWidth="150"
              dd:DragDrop.IsDragSource="True"
              dd:DragDrop.IsDropTarget="True"
              dd:DragDrop.UseDefaultEffectDataTemplate="True">
        <ListViewItem>Unbound Item1</ListViewItem>
        <ListViewItem>Unbound Item2</ListViewItem>
        <ListViewItem>Unbound Item3</ListViewItem>
        <ListViewItem>Unbound Item4</ListViewItem>
        <ListViewItem>Unbound Item5</ListViewItem>
    </ListView>
</Grid>
```
