### PR TITLE
Added DropTargetScrollViewer property

### DIFF
--- a/src/GongSolutions.WPF.DragDrop.Shared/DragDrop.Properties.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DragDrop.Properties.cs
@@ -919,5 +919,30 @@ namespace GongSolutions.Wpf.DragDrop
         {
             target.SetValue(SelectDroppedItemsProperty, value);
         }
+
+        /// <summary>
+        /// Gets or sets the <see cref="ScrollViewer"/> that will be used as <see cref="DropInfo.TargetScrollViewer"/>.
+        /// </summary>
+        public static readonly DependencyProperty DropTargetScrollViewerProperty
+            = DependencyProperty.RegisterAttached("DropTargetScrollViewer",
+                                                  typeof(ScrollViewer),
+                                                  typeof(DragDrop),
+                                                  new PropertyMetadata((ScrollViewer)null));
+
+        /// <summary>
+        /// Sets the <see cref="ScrollViewer"/> that will be used as <see cref="DropInfo.TargetScrollViewer"/>.
+        /// </summary>
+        public static void SetDropTargetScrollViewer(DependencyObject element, ScrollViewer value)
+        {
+            element.SetValue(DropTargetScrollViewerProperty, value);
+        }
+
+        /// <summary>
+        /// Gets the <see cref="ScrollViewer"/> that will be used as <see cref="DropInfo.TargetScrollViewer"/>.
+        /// </summary>
+        public static ScrollViewer GetDropTargetScrollViewer(DependencyObject element)
+        {
+            return (ScrollViewer)element?.GetValue(DropTargetScrollViewerProperty);
+        }
     }
 }

--- a/src/GongSolutions.WPF.DragDrop.Shared/DropInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DropInfo.cs
@@ -60,7 +60,12 @@ namespace GongSolutions.Wpf.DragDrop
             }
 
             // try find ScrollViewer
-            if (this.VisualTarget is TabControl)
+            var dropTargetScrollViewer = DragDrop.GetDropTargetScrollViewer(this.VisualTarget);
+            if (dropTargetScrollViewer != null)
+            {
+                this.TargetScrollViewer = dropTargetScrollViewer;
+            }
+            else if (this.VisualTarget is TabControl)
             {
                 var tabPanel = this.VisualTarget.GetVisualDescendent<TabPanel>();
                 this.TargetScrollViewer = tabPanel?.GetVisualAncestor<ScrollViewer>();


### PR DESCRIPTION
## What changed?
I added an attached property called `DropTargetScrollViewer`.

It is helpful if you have a ScrollViewer wrapping several elements (that have their own ScrollViewers) and you want the outer ScrollViewer to scroll automatically when hovering at the edge of the view.

I've needed this twice now, so I figured it might be worth a PR.