### PR TITLE
Add dependency property DropEventType

### DIFF
--- a/src/GongSolutions.WPF.DragDrop.Shared/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DragDrop.cs
@@ -6,9 +6,9 @@ using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Media.Imaging;
 using GongSolutions.Wpf.DragDrop.Icons;
 using GongSolutions.Wpf.DragDrop.Utilities;
-using System.Windows.Media.Imaging;
 #if NET35
 using Microsoft.Windows.Controls;
 #endif
@@ -240,19 +240,19 @@ namespace GongSolutions.Wpf.DragDrop
                                      new GradientStop(Colors.AliceBlue, 1.0)
                                  };
             var gradientBrush = new LinearGradientBrush(stopCollection)
-                                {
-                                    StartPoint = new Point(0, 0),
-                                    EndPoint = new Point(0, 1)
-                                };
+            {
+                StartPoint = new Point(0, 0),
+                EndPoint = new Point(0, 1)
+            };
             borderFactory.SetValue(Panel.BackgroundProperty, gradientBrush);
             borderFactory.SetValue(Border.BorderBrushProperty, Brushes.DimGray);
             borderFactory.SetValue(Border.CornerRadiusProperty, new CornerRadius(3));
             borderFactory.SetValue(Border.BorderThicknessProperty, new Thickness(1));
             borderFactory.SetValue(Border.SnapsToDevicePixelsProperty, true);
 #if !NET35
-      borderFactory.SetValue(TextOptions.TextFormattingModeProperty, TextFormattingMode.Display);
-      borderFactory.SetValue(TextOptions.TextRenderingModeProperty, TextRenderingMode.ClearType);
-      borderFactory.SetValue(TextOptions.TextHintingModeProperty, TextHintingMode.Fixed);
+            borderFactory.SetValue(TextOptions.TextFormattingModeProperty, TextFormattingMode.Display);
+            borderFactory.SetValue(TextOptions.TextRenderingModeProperty, TextRenderingMode.ClearType);
+            borderFactory.SetValue(TextOptions.TextHintingModeProperty, TextHintingMode.Fixed);
 #endif
             borderFactory.AppendChild(stackPanelFactory);
 
@@ -351,7 +351,7 @@ namespace GongSolutions.Wpf.DragDrop
         private static void DoMouseButtonDown(object sender, MouseButtonEventArgs e)
         {
             m_DragInfo = null;
-            
+
             // Ignore the click if clickCount != 1 or the user has clicked on a scrollbar.
             var elementPosition = e.GetPosition((IInputElement)sender);
             if (e.ClickCount != 1
@@ -536,7 +536,12 @@ namespace GongSolutions.Wpf.DragDrop
 
         private static void DropTargetOnDragEnter(object sender, DragEventArgs e)
         {
-            DropTargetOnDragOver(sender, e);
+            DropTargetOnDragOver(sender, e, EventType.Bubbled);
+        }
+
+        private static void DropTargetOnPreviewDragEnter(object sender, DragEventArgs e)
+        {
+            DropTargetOnDragOver(sender, e, EventType.Tunneled);
         }
 
         private static void DropTargetOnDragLeave(object sender, DragEventArgs e)
@@ -548,10 +553,20 @@ namespace GongSolutions.Wpf.DragDrop
 
         private static void DropTargetOnDragOver(object sender, DragEventArgs e)
         {
+            DropTargetOnDragOver(sender, e, EventType.Bubbled);
+        }
+
+        private static void DropTargetOnPreviewDragOver(object sender, DragEventArgs e)
+        {
+            DropTargetOnDragOver(sender, e, EventType.Tunneled);
+        }
+
+        private static void DropTargetOnDragOver(object sender, DragEventArgs e, EventType eventType)
+        {
             var elementPosition = e.GetPosition((IInputElement)sender);
 
             var dragInfo = m_DragInfo;
-            var dropInfo = new DropInfo(sender, e, dragInfo);
+            var dropInfo = new DropInfo(sender, e, dragInfo, eventType);
             var dropHandler = TryGetDropHandler(dropInfo, sender as UIElement);
             var itemsControl = dropInfo.VisualTarget;
 
@@ -680,8 +695,18 @@ namespace GongSolutions.Wpf.DragDrop
 
         private static void DropTargetOnDrop(object sender, DragEventArgs e)
         {
+            DropTargetOnDrop(sender, e, EventType.Bubbled);
+        }
+
+        private static void DropTargetOnPreviewDrop(object sender, DragEventArgs e)
+        {
+            DropTargetOnDrop(sender, e, EventType.Tunneled);
+        }
+
+        private static void DropTargetOnDrop(object sender, DragEventArgs e, EventType eventType)
+        {
             var dragInfo = m_DragInfo;
-            var dropInfo = new DropInfo(sender, e, dragInfo);
+            var dropInfo = new DropInfo(sender, e, dragInfo, eventType);
             var dropHandler = TryGetDropHandler(dropInfo, sender as UIElement);
             var dragHandler = TryGetDragHandler(dragInfo, sender as UIElement);
 

--- a/src/GongSolutions.WPF.DragDrop.Shared/DropInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/DropInfo.cs
@@ -40,10 +40,15 @@ namespace GongSolutions.Wpf.DragDrop
         /// <param name="dragInfo">
         /// Information about the source of the drag, if the drag came from within the framework.
         /// </param>
-        public DropInfo(object sender, DragEventArgs e, [CanBeNull] DragInfo dragInfo)
+        /// 
+        /// <param name="eventType">
+        /// The type of the underlying event (tunneled or bubbled).
+        /// </param>
+        public DropInfo(object sender, DragEventArgs e, [CanBeNull] DragInfo dragInfo, EventType eventType)
         {
             this.DragInfo = dragInfo;
             this.KeyStates = e.KeyStates;
+            this.EventType = eventType;
             var dataFormat = dragInfo?.DataFormat;
             this.Data = dataFormat != null && e.Data.GetDataPresent(dataFormat.Name) ? e.Data.GetData(dataFormat.Name) : e.Data;
 
@@ -425,6 +430,11 @@ namespace GongSolutions.Wpf.DragDrop
                 return string.Equals(sourceContext, targetContext);
             }
         }
+
+        /// <summary>
+        /// Gets the current mode of the underlying routed event.
+        /// </summary>
+        public EventType EventType { get; }
     }
 
     [Flags]

--- a/src/GongSolutions.WPF.DragDrop.Shared/EventType.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/EventType.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GongSolutions.Wpf.DragDrop
+{
+    public enum EventType
+    {
+        Auto,
+        Tunneled,
+        Bubbled,
+        TunneledBubbled
+    }
+}

--- a/src/GongSolutions.WPF.DragDrop.Shared/GongSolutions.WPF.DragDrop.Shared.projitems
+++ b/src/GongSolutions.WPF.DragDrop.Shared/GongSolutions.WPF.DragDrop.Shared.projitems
@@ -23,6 +23,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)..\GlobalAssemblyInfo.cs">
       <Link>GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)EventType.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Icons\IconFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IDragInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IDragSource.cs" />

--- a/src/GongSolutions.WPF.DragDrop.Shared/IDropInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop.Shared/IDropInfo.cs
@@ -146,5 +146,10 @@ namespace GongSolutions.Wpf.DragDrop
         /// Gets a value indicating whether the target is in the same context as the source, <see cref="DragDrop.DragDropContextProperty" />.
         /// </summary>
         bool IsSameDragDropContextAsSource { get; }
+
+        /// <summary>
+        /// Gets the current mode of the underlying routed event.
+        /// </summary>
+        EventType EventType { get; }
     }
 }


### PR DESCRIPTION
With this version, there is a new dependency property `DropEventType` to specify which events should be handled for the IDropTarget:

* `Auto` - The default value and the current implementation which uses the preview events if the control is an ItemsControl and the normal events otherwise
* `Tunneled` - DragDrop will always subscribe to the tunneled (Preview) events
* `Bubbled` - DragDrop will always subscribe to the bubbled events
* `TunneledBubbled` - DragDrop will subscribe to the tunneled and the bubbled events

Also the `IDropInfo` interface has a new property `EventType` which shows from which event the IDropInfo object was created. It has the value `Tunneled` if it was created from a Preview event or `Bubbled` if it was created from a bubbled event.
This is needed for the event type `TunneledBubbled` so that the IDropTarget can distinguish between a Preview event and a normal event.

This should fix the issues #159 and #287 because now can specify which type of events should be subscribed for a drop target.

This pull request changes nothing for existing applications because the default value of the new dependency property is `Auto` which uses the current implementation.