### PR TITLE
Fix the file not found exception in opening urls.

### DIFF
--- a/src/Showcase/ViewModels/MainViewModel.cs
+++ b/src/Showcase/ViewModels/MainViewModel.cs
@@ -54,9 +54,12 @@ namespace Showcase.WPF.DragDrop.ViewModels
             Members.Add(listMember);
 
             this.Data = new SampleData();
-            this.OpenIssueCommand = new SimpleCommand(issue => { Process.Start($"https://github.com/punker76/gong-wpf-dragdrop/issues/{issue}"); });
-            this.OpenPullRequestCommand = new SimpleCommand(pr => { Process.Start($"https://github.com/punker76/gong-wpf-dragdrop/pull/{pr}"); });
-            this.OpenLinkCommand = new SimpleCommand(link => { Process.Start(link.ToString()); });
+            this.OpenIssueCommand = new SimpleCommand(issue =>
+            {
+                OpenUrlLink($"https://github.com/punker76/gong-wpf-dragdrop/issues/{issue}");
+            });
+            this.OpenPullRequestCommand = new SimpleCommand(pr => { OpenUrlLink($"https://github.com/punker76/gong-wpf-dragdrop/pull/{pr}"); });
+            this.OpenLinkCommand = new SimpleCommand(link => { OpenUrlLink(link.ToString()); });
             this.FilterCollectionCommand = new SimpleCommand(isChecked =>
                 {
                     var coll = Data.FilterCollection1;
@@ -72,6 +75,14 @@ namespace Showcase.WPF.DragDrop.ViewModels
                             return (number & 0x01) == 0;
                         };
                 });
+
+            static void OpenUrlLink(string link) => Process.Start(new ProcessStartInfo
+            {
+                FileName = link ?? throw new System.ArgumentNullException(nameof(link)),
+                // UseShellExecute is default to false on .NET Core while true on .NET Framework.
+                // Only this value is set to true, the url link can be opened.
+                UseShellExecute = true,
+            });
         }
 
         public SampleData Data


### PR DESCRIPTION
## What changed?

When clicking on the URL link icon to open GitHub issues, the demo app crashes.

This is a difference between .NET Core and .NET Framework. Because we targets both .NET Core and .NET Framework so this issue should be fixed.

![image](https://user-images.githubusercontent.com/9959623/65672882-5cdc0380-e07c-11e9-917a-a089975acea4.png)

See my post for more details:

- [What is the UseShellExecute in processes starting? What's the difference of its behavior on .NET Core and .NET Framework - walterlv](https://blog.walterlv.com/post/use-shell-execute-in-process-start-info.html)