### PR TITLE
Fix DefaultDropHandler.TestCompatibleTypes for any IEditableCollectionView

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/DefaultDropHandler.cs
+++ b/src/GongSolutions.WPF.DragDrop/DefaultDropHandler.cs
@@ -267,7 +267,7 @@ namespace GongSolutions.Wpf.DragDrop
             }
             else
             {
-                return target is IList || target is IEditableCollectionView;
+                return target is IList || target is ICollectionView;
             }
         }
     }

--- a/src/GongSolutions.WPF.DragDrop/DefaultDropHandler.cs
+++ b/src/GongSolutions.WPF.DragDrop/DefaultDropHandler.cs
@@ -267,7 +267,7 @@ namespace GongSolutions.Wpf.DragDrop
             }
             else
             {
-                return target is IList;
+                return target is IList || target is IEditableCollectionView;
             }
         }
     }

--- a/src/GongSolutions.WPF.DragDrop/DefaultDropHandler.cs
+++ b/src/GongSolutions.WPF.DragDrop/DefaultDropHandler.cs
@@ -254,13 +254,13 @@ namespace GongSolutions.Wpf.DragDrop
 
         protected static bool TestCompatibleTypes(IEnumerable target, object data)
         {
-            TypeFilter filter = (t, o) => { return (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IEnumerable<>)); };
+            bool InterfaceFilter(Type t, object o) => (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IEnumerable<>));
 
-            var enumerableInterfaces = target.GetType().FindInterfaces(filter, null);
+            var enumerableInterfaces = target.GetType().FindInterfaces(InterfaceFilter, null);
             var enumerableTypes = from i in enumerableInterfaces
                                   select i.GetGenericArguments().Single();
 
-            if (enumerableTypes.Count() > 0)
+            if (enumerableTypes.Any())
             {
                 var dataType = TypeUtilities.GetCommonBaseClass(ExtractData(data));
                 return enumerableTypes.Any(t => t.IsAssignableFrom(dataType));


### PR DESCRIPTION
In the `DefaultDropHandler`:
`TestCompatibleTypes` does not consider any `IEditableCollectionView`:

```c#
...
else
{
    return target is IList;
}
```

This causes `CanAcceptData` to always reject any targets that are `IEditableCollectionView`, however `Drop` is able to handle them.

I simply modified it to: 
```c#
return target is IList || target is IEditableCollectionView;
```

I also added some minor cleanups for the same function.