### PR TITLE
Added CanTreeViewItemAcceptChildren property

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/DefaultDropHandler.cs
+++ b/src/GongSolutions.WPF.DragDrop/DefaultDropHandler.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
 using GongSolutions.Wpf.DragDrop.Utilities;
@@ -147,8 +146,16 @@ namespace GongSolutions.Wpf.DragDrop
             if (CanAcceptData(dropInfo))
             {
                 dropInfo.Effects = ShouldCopyData(dropInfo) ? DragDropEffects.Copy : DragDropEffects.Move;
-                var isTreeViewItem = dropInfo.InsertPosition.HasFlag(RelativeInsertPosition.TargetItemCenter) && dropInfo.VisualTargetItem is TreeViewItem;
-                dropInfo.DropTargetAdorner = isTreeViewItem ? DropTargetAdorners.Highlight : DropTargetAdorners.Insert;
+                if (dropInfo.InsertPosition.HasFlag(RelativeInsertPosition.TargetItemCenter)
+                    && dropInfo.VisualTargetItem is TreeViewItem treeViewItem
+                    && DragDrop.GetCanTreeViewItemAcceptChildren(treeViewItem))
+                {
+                    dropInfo.DropTargetAdorner = DropTargetAdorners.Highlight;
+                }
+                else
+                {
+                    dropInfo.DropTargetAdorner = DropTargetAdorners.Insert;
+                }
             }
         }
 

--- a/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
@@ -1113,5 +1113,31 @@ namespace GongSolutions.Wpf.DragDrop
         {
             return (ScrollViewer)element?.GetValue(DropTargetScrollViewerProperty);
         }
+
+        /// <summary>
+        /// Gets or sets whether a <see cref="TreeViewItem"/> can accept children.
+        /// Default is <see langword="true" />.
+        /// </summary>
+        public static readonly DependencyProperty CanTreeViewItemAcceptChildrenProperty = DependencyProperty.RegisterAttached(
+            "CanTreeViewItemAcceptChildren",
+            typeof(bool),
+            typeof(DragDrop),
+            new PropertyMetadata(true));
+
+        /// <summary>
+        /// Sets whether a <see cref="TreeViewItem"/> can accept children.
+        /// </summary>
+        public static void SetCanTreeViewItemAcceptChildren(DependencyObject element, bool value)
+        {
+            element.SetValue(CanTreeViewItemAcceptChildrenProperty, value);
+        }
+
+        /// <summary>
+        /// Gets whether a <see cref="TreeViewItem"/> can accept children.
+        /// </summary>
+        public static bool GetCanTreeViewItemAcceptChildren(DependencyObject element)
+        {
+            return (bool)element.GetValue(CanTreeViewItemAcceptChildrenProperty);
+        }
     }
 }

--- a/src/GongSolutions.WPF.DragDrop/DropInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop/DropInfo.cs
@@ -171,7 +171,7 @@ namespace GongSolutions.Wpf.DragDrop
 
                         if (currentYPos > topGap && currentYPos < bottomGap)
                         {
-                            if (tvItem != null)
+                            if (tvItem != null && DragDrop.GetCanTreeViewItemAcceptChildren(tvItem))
                             {
                                 this.TargetCollection = tvItem.ItemsSource ?? tvItem.Items;
                                 this.InsertIndex = this.TargetCollection != null ? this.TargetCollection.OfType<object>().Count() : 0;
@@ -212,7 +212,7 @@ namespace GongSolutions.Wpf.DragDrop
 
                         if (currentXPos > targetWidth * 0.25 && currentXPos < targetWidth * 0.75)
                         {
-                            if (tvItem != null)
+                            if (tvItem != null && DragDrop.GetCanTreeViewItemAcceptChildren(tvItem))
                             {
                                 this.TargetCollection = tvItem.ItemsSource ?? tvItem.Items;
                                 this.InsertIndex = this.TargetCollection != null ? this.TargetCollection.OfType<object>().Count() : 0;


### PR DESCRIPTION
## What changed?

I have added an attached property called `GetCanTreeViewItemAcceptChildren`. This property is useful if you have specific tree view items that are not meant to have children.

Fixes #344