### PR TITLE
Support using a custom RootElementFinder

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using GongSolutions.WPF.DragDrop.Utilities;
+using System;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -1112,6 +1113,30 @@ namespace GongSolutions.Wpf.DragDrop
         public static ScrollViewer GetDropTargetScrollViewer(DependencyObject element)
         {
             return (ScrollViewer)element?.GetValue(DropTargetScrollViewerProperty);
+        }
+
+        /// <summary>
+        /// Gets or sets the root element finder.
+        /// </summary>
+        public static readonly DependencyProperty RootElementFinderProperty
+            = DependencyProperty.RegisterAttached("RootElementFinder",
+                                                  typeof(IRootElementFinder),
+                                                  typeof(DragDrop));
+
+        /// <summary>
+        /// Gets the root element finder.
+        /// </summary>
+        public static IRootElementFinder GetRootElementFinder(UIElement target)
+        {
+            return (IRootElementFinder)target.GetValue(RootElementFinderProperty);
+        }
+
+        /// <summary>
+        /// Sets the root element finder.
+        /// </summary>
+        public static void SetRootElementFinder(UIElement target, IRootElementFinder value)
+        {
+            target.SetValue(RootElementFinderProperty, value);
         }
     }
 }

--- a/src/GongSolutions.WPF.DragDrop/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.cs
@@ -9,12 +9,13 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using GongSolutions.Wpf.DragDrop.Icons;
 using GongSolutions.Wpf.DragDrop.Utilities;
+using GongSolutions.WPF.DragDrop.Utilities;
 
 namespace GongSolutions.Wpf.DragDrop
 {
     public static partial class DragDrop
     {
-        private static void CreateDragAdorner(DropInfo dropInfo)
+        private static void CreateDragAdorner(DropInfo dropInfo, UIElement sender)
         {
             var dragInfo = dropInfo.DragInfo;
             var template = GetDropAdornerTemplate(dropInfo.VisualTarget) ?? GetDragAdornerTemplate(dragInfo.VisualSource);
@@ -81,19 +82,19 @@ namespace GongSolutions.Wpf.DragDrop
                     adornment.Opacity = GetDefaultDragAdornerOpacity(dragInfo.VisualSource);
                 }
 
-                var rootElement = RootElementFinder.FindRoot(dropInfo.VisualTarget ?? dragInfo.VisualSource);
+                var rootElement = TryGetRootElementFinder(sender).FindRoot(dropInfo.VisualTarget ?? dragInfo.VisualSource);
                 DragAdorner = new DragAdorner(rootElement, adornment, GetDragAdornerTranslation(dragInfo.VisualSource));
             }
         }
 
-        private static void CreateEffectAdorner(DropInfo dropInfo)
+        private static void CreateEffectAdorner(DropInfo dropInfo, UIElement sender)
         {
             var dragInfo = m_DragInfo;
             var template = GetEffectAdornerTemplate(dragInfo.VisualSource, dropInfo.Effects, dropInfo.DestinationText, dropInfo.EffectText);
 
             if (template != null)
             {
-                var rootElement = RootElementFinder.FindRoot(dropInfo.VisualTarget ?? dragInfo.VisualSource);
+                var rootElement = TryGetRootElementFinder(sender).FindRoot(dropInfo.VisualTarget ?? dragInfo.VisualSource);
 
                 var adornment = new ContentPresenter();
                 adornment.Content = dragInfo.Data;
@@ -278,6 +279,21 @@ namespace GongSolutions.Wpf.DragDrop
                 dropHandler = GetDropHandler(sender);
             }
             return dropHandler ?? DefaultDropHandler;
+        }
+
+        /// <summary>
+        /// Gets the root element handler from the sender or uses the default implementation, if it is null.
+        /// </summary>
+        /// <param name="sender">the sender from an event, e.g. drag over</param>
+        /// <returns></returns>
+        private static IRootElementFinder TryGetRootElementFinder(UIElement sender)
+        {
+            IRootElementFinder rootElementFinder = null;
+            if (sender != null)
+            {
+                rootElementFinder = GetRootElementFinder(sender);
+            }
+            return rootElementFinder ?? new RootElementFinder();
         }
 
         private static void DragSourceOnMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
@@ -521,7 +537,7 @@ namespace GongSolutions.Wpf.DragDrop
 
             if (DragAdorner == null && dragInfo != null)
             {
-                CreateDragAdorner(dropInfo);
+                CreateDragAdorner(dropInfo, sender as UIElement);
             }
 
             DragAdorner?.Move(e.GetPosition(DragAdorner.AdornedElement), dragInfo != null ? GetDragMouseAnchorPoint(dragInfo.VisualSource) : default(Point), ref _adornerMousePosition, ref _adornerSize);
@@ -585,7 +601,7 @@ namespace GongSolutions.Wpf.DragDrop
             // Set the drag effect adorner if there is one
             if (dragInfo != null && (EffectAdorner == null || EffectAdorner.Effects != dropInfo.Effects))
             {
-                CreateEffectAdorner(dropInfo);
+                CreateEffectAdorner(dropInfo, sender as UIElement);
             }
 
             EffectAdorner?.Move(e.GetPosition(EffectAdorner.AdornedElement), default(Point), ref _effectAdornerMousePosition, ref _effectAdornerSize);

--- a/src/GongSolutions.WPF.DragDrop/Utilities/IRootElementFinder.cs
+++ b/src/GongSolutions.WPF.DragDrop/Utilities/IRootElementFinder.cs
@@ -1,0 +1,17 @@
+﻿using System.Windows;
+
+namespace GongSolutions.WPF.DragDrop.Utilities
+{
+    /// <summary>
+    /// Interface implemented by the root element finder.
+    /// </summary>
+    public interface IRootElementFinder
+    {
+        /// <summary>
+        /// Gets the root element.
+        /// </summary>
+        /// <param name="visual">The visual element to find the root for.</param>
+        /// <returns>The root element.</returns>
+        UIElement FindRoot(DependencyObject visual);
+    }
+}

--- a/src/GongSolutions.WPF.DragDrop/Utilities/RootElementFinder.cs
+++ b/src/GongSolutions.WPF.DragDrop/Utilities/RootElementFinder.cs
@@ -1,11 +1,12 @@
-﻿using System.Windows;
+﻿using GongSolutions.WPF.DragDrop.Utilities;
+using System.Windows;
 using System.Windows.Controls;
 
 namespace GongSolutions.Wpf.DragDrop.Utilities
 {
-    public static class RootElementFinder
+    public class RootElementFinder : IRootElementFinder
     {
-        public static UIElement FindRoot(DependencyObject visual)
+        public UIElement FindRoot(DependencyObject visual)
         {
             var parentWindow = Window.GetWindow(visual);
             var rootElement = parentWindow != null ? parentWindow.Content as UIElement : null;
@@ -20,6 +21,7 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
                     rootElement = visual.GetVisualAncestor<Page>() ?? visual.GetVisualAncestor<UserControl>() as UIElement;
                 }
             }
+
             //      i don't want the fu... windows forms reference
             //      if (rootElement == null) {
             //          var elementHost = m_DragInfo.VisualSource.GetVisualAncestor<ElementHost>();


### PR DESCRIPTION
This adds support for providing a custom RootElementFinder, rather than the static version that exists in the project.

We use GongDragDrop in a project that is also using AvalonDock.  When floating windows, we found that the existing code is incorrectly finding a HwndHost as the root element due to how they setting it as the content here:
https://github.com/xceedsoftware/wpftoolkit/blob/master/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Controls/LayoutFloatingWindowControl.cs

We'd be able to work around that edge case (which doesn't quite seem correct), if we had a way to provide our own logic for the RootElementFinder for this particular instance.