### PR TITLE
Implement drag drop touch screen

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
@@ -72,6 +72,11 @@ namespace GongSolutions.Wpf.DragDrop
                 uiElement.PreviewMouseLeftButtonDown += DragSourceOnMouseLeftButtonDown;
                 uiElement.PreviewMouseLeftButtonUp += DragSourceOnMouseLeftButtonUp;
                 uiElement.PreviewMouseMove += DragSourceOnMouseMove;
+
+                uiElement.PreviewTouchDown += DragSourceOnTouchDown;
+                uiElement.PreviewTouchUp += DragSourceOnTouchUp;
+                uiElement.PreviewTouchMove += DragSourceOnTouchMove;
+
                 uiElement.QueryContinueDrag += DragSourceOnQueryContinueDrag;
             }
             else
@@ -79,6 +84,11 @@ namespace GongSolutions.Wpf.DragDrop
                 uiElement.PreviewMouseLeftButtonDown -= DragSourceOnMouseLeftButtonDown;
                 uiElement.PreviewMouseLeftButtonUp -= DragSourceOnMouseLeftButtonUp;
                 uiElement.PreviewMouseMove -= DragSourceOnMouseMove;
+
+                uiElement.PreviewTouchDown -= DragSourceOnTouchDown;
+                uiElement.PreviewTouchUp -= DragSourceOnTouchUp;
+                uiElement.PreviewTouchMove -= DragSourceOnTouchMove;
+
                 uiElement.QueryContinueDrag -= DragSourceOnQueryContinueDrag;
             }
         }

--- a/src/GongSolutions.WPF.DragDrop/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.cs
@@ -299,13 +299,7 @@ namespace GongSolutions.Wpf.DragDrop
             if ((sender as UIElement).IsDragSourceIgnored()
                 || (e.Source as UIElement).IsDragSourceIgnored()
                 || (e.OriginalSource as UIElement).IsDragSourceIgnored()
-                || (sender is TabControl) && !HitTestUtilities.HitTest4Type<TabPanel>(sender, elementPosition)
-                || HitTestUtilities.HitTest4Type<RangeBase>(sender, elementPosition)
-                || HitTestUtilities.HitTest4Type<TextBoxBase>(sender, elementPosition)
-                || HitTestUtilities.HitTest4Type<PasswordBox>(sender, elementPosition)
-                || HitTestUtilities.HitTest4Type<ComboBox>(sender, elementPosition)
-                || HitTestUtilities.HitTest4GridViewColumnHeader(sender, elementPosition)
-                || HitTestUtilities.HitTest4DataGridTypes(sender, elementPosition)
+                || GetHitTestResult(sender, elementPosition)
                 || HitTestUtilities.IsNotPartOfSender(sender, e))
             {
                 return;
@@ -326,13 +320,7 @@ namespace GongSolutions.Wpf.DragDrop
                 || (sender as UIElement).IsDragSourceIgnored()
                 || (e.Source as UIElement).IsDragSourceIgnored()
                 || (e.OriginalSource as UIElement).IsDragSourceIgnored()
-                || (sender is TabControl) && !HitTestUtilities.HitTest4Type<TabPanel>(sender, elementPosition)
-                || HitTestUtilities.HitTest4Type<RangeBase>(sender, elementPosition)
-                || HitTestUtilities.HitTest4Type<TextBoxBase>(sender, elementPosition)
-                || HitTestUtilities.HitTest4Type<PasswordBox>(sender, elementPosition)
-                || HitTestUtilities.HitTest4Type<ComboBox>(sender, elementPosition)
-                || HitTestUtilities.HitTest4GridViewColumnHeader(sender, elementPosition)
-                || HitTestUtilities.HitTest4DataGridTypes(sender, elementPosition)
+                || GetHitTestResult(sender, elementPosition)
                 || HitTestUtilities.IsNotPartOfSender(sender, e))
             {
                 return;
@@ -711,6 +699,18 @@ namespace GongSolutions.Wpf.DragDrop
                     Mouse.OverrideCursor = null;
                 }
             }
+        }
+
+        private static bool GetHitTestResult(object sender, Point elementPosition)
+        {
+            return (sender is TabControl) 
+                && !HitTestUtilities.HitTest4Type<TabPanel>(sender, elementPosition)
+                || HitTestUtilities.HitTest4Type<RangeBase>(sender, elementPosition)
+                || HitTestUtilities.HitTest4Type<TextBoxBase>(sender, elementPosition)
+                || HitTestUtilities.HitTest4Type<PasswordBox>(sender, elementPosition)
+                || HitTestUtilities.HitTest4Type<ComboBox>(sender, elementPosition)
+                || HitTestUtilities.HitTest4GridViewColumnHeader(sender, elementPosition)
+                || HitTestUtilities.HitTest4DataGridTypes(sender, elementPosition);
         }
 
         private static DragAdorner _DragAdorner;

--- a/src/GongSolutions.WPF.DragDrop/DragInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragInfo.cs
@@ -33,122 +33,15 @@ namespace GongSolutions.Wpf.DragDrop
         /// </param>
         public DragInfo(object sender, MouseButtonEventArgs e)
         {
-            this.Effects = DragDropEffects.None;
-            this.MouseButton = e.ChangedButton;
-            this.VisualSource = sender as UIElement;
-            this.DragStartPosition = e.GetPosition(this.VisualSource);
-            this.DragDropCopyKeyState = DragDrop.GetDragDropCopyKeyState(this.VisualSource);
-
-            var dataFormat = DragDrop.GetDataFormat(this.VisualSource);
-            if (dataFormat != null)
-            {
-                this.DataFormat = dataFormat;
-            }
-
-            var sourceElement = e.OriginalSource as UIElement;
-            // If we can't cast object as a UIElement it might be a FrameworkContentElement, if so try and use its parent.
-            if (sourceElement == null && e.OriginalSource is FrameworkContentElement)
-            {
-                sourceElement = ((FrameworkContentElement)e.OriginalSource).Parent as UIElement;
-            }
-
-            if (sender is ItemsControl)
-            {
-                var itemsControl = (ItemsControl)sender;
-
-                this.SourceGroup = itemsControl.FindGroup(this.DragStartPosition);
-                this.VisualSourceFlowDirection = itemsControl.GetItemsPanelFlowDirection();
-
-                UIElement item = null;
-                if (sourceElement != null)
-                {
-                    item = itemsControl.GetItemContainer(sourceElement);
-                }
-
-                if (item == null)
-                {
-                    if (DragDrop.GetDragDirectlySelectedOnly(this.VisualSource))
-                    {
-                        item = itemsControl.GetItemContainerAt(e.GetPosition(itemsControl));
-                    }
-                    else
-                    {
-                        item = itemsControl.GetItemContainerAt(e.GetPosition(itemsControl), itemsControl.GetItemsPanelOrientation());
-                    }
-                }
-
-                if (item != null)
-                {
-                    // Remember the relative position of the item being dragged
-                    this.PositionInDraggedItem = e.GetPosition(item);
-
-                    var itemParent = ItemsControl.ItemsControlFromItemContainer(item);
-
-                    if (itemParent != null)
-                    {
-                        this.SourceCollection = itemParent.ItemsSource ?? itemParent.Items;
-                        if (itemParent != itemsControl)
-                        {
-                            var tvItem = item as TreeViewItem;
-                            if (tvItem != null)
-                            {
-                                var tv = tvItem.GetVisualAncestor<TreeView>();
-                                if (tv != null && tv != itemsControl && !tv.IsDragSource())
-                                {
-                                    return;
-                                }
-                            }
-                            else if (itemsControl.ItemContainerGenerator.IndexFromContainer(itemParent) < 0 && !itemParent.IsDragSource())
-                            {
-                                return;
-                            }
-                        }
-                        this.SourceIndex = itemParent.ItemContainerGenerator.IndexFromContainer(item);
-                        this.SourceItem = itemParent.ItemContainerGenerator.ItemFromContainer(item);
-                    }
-                    else
-                    {
-                        this.SourceIndex = -1;
-                    }
-
-                    var selectedItems = itemsControl.GetSelectedItems().OfType<object>().Where(i => i != CollectionView.NewItemPlaceholder).ToList();
-                    this.SourceItems = selectedItems;
-
-                    // Some controls (I'm looking at you TreeView!) haven't updated their
-                    // SelectedItem by this point. Check to see if there 1 or less item in 
-                    // the SourceItems collection, and if so, override the control's SelectedItems with the clicked item.
-                    //
-                    // The control has still the old selected items at the mouse down event, so we should check this and give only the real selected item to the user.
-                    if (selectedItems.Count <= 1 || this.SourceItem != null && !selectedItems.Contains(this.SourceItem))
-                    {
-                        this.SourceItems = Enumerable.Repeat(this.SourceItem, 1);
-                    }
-
-                    this.VisualSourceItem = item;
-                }
-                else
-                {
-                    this.SourceCollection = itemsControl.ItemsSource ?? itemsControl.Items;
-                }
-            }
-            else
-            {
-                this.SourceItem = (sender as FrameworkElement)?.DataContext;
-                if (this.SourceItem != null)
-                {
-                    this.SourceItems = Enumerable.Repeat(this.SourceItem, 1);
-                }
-                this.VisualSourceItem = sourceElement;
-                this.PositionInDraggedItem = sourceElement != null ? e.GetPosition(sourceElement) : this.DragStartPosition;
-            }
-
-            if (this.SourceItems == null)
-            {
-                this.SourceItems = Enumerable.Empty<object>();
-            }
+            InitializeDragInfo(sender, e.OriginalSource, (item) => e.GetPosition(item));
         }
 
-        internal void RefreshSelectedItems(object sender, MouseEventArgs e)
+        public DragInfo(object sender, TouchEventArgs e)
+        {
+            InitializeDragInfo(sender, e.OriginalSource, (item) => e.GetTouchPoint(item).Position);
+        }
+
+        internal void RefreshSelectedItems(object sender)
         {
             if (sender is ItemsControl)
             {
@@ -219,5 +112,122 @@ namespace GongSolutions.Wpf.DragDrop
 
         /// <inheritdoc />
         public DragDropKeyStates DragDropCopyKeyState { get; private set; }
+
+        private void InitializeDragInfo(object sender, object originalSource, Func<IInputElement, Point> getPosition)
+        {
+            this.Effects = DragDropEffects.None;
+            this.MouseButton = MouseButton.Left;
+            this.VisualSource = sender as UIElement;
+            this.DragStartPosition = getPosition(this.VisualSource);
+            this.DragDropCopyKeyState = DragDrop.GetDragDropCopyKeyState(this.VisualSource);
+
+            var dataFormat = DragDrop.GetDataFormat(this.VisualSource);
+            if (dataFormat != null)
+            {
+                this.DataFormat = dataFormat;
+            }
+
+            var sourceElement = originalSource as UIElement;
+            // If we can't cast object as a UIElement it might be a FrameworkContentElement, if so try and use its parent.
+            if (sourceElement == null && originalSource is FrameworkContentElement frameworkContentElement)
+            {
+                sourceElement = frameworkContentElement.Parent as UIElement;
+            }
+
+            if (sender is ItemsControl itemsControl)
+            {
+                this.SourceGroup = itemsControl.FindGroup(this.DragStartPosition);
+                this.VisualSourceFlowDirection = itemsControl.GetItemsPanelFlowDirection();
+
+                UIElement item = null;
+                if (sourceElement != null)
+                {
+                    item = itemsControl.GetItemContainer(sourceElement);
+                }
+
+                if (item == null)
+                {
+                    var itemPosition = getPosition(itemsControl);
+
+                    if (DragDrop.GetDragDirectlySelectedOnly(this.VisualSource))
+                    {
+                        item = itemsControl.GetItemContainerAt(itemPosition);
+                    }
+                    else
+                    {
+                        item = itemsControl.GetItemContainerAt(itemPosition, itemsControl.GetItemsPanelOrientation());
+                    }
+                }
+
+                if (item != null)
+                {
+                    // Remember the relative position of the item being dragged
+                    this.PositionInDraggedItem = getPosition(item);
+
+                    var itemParent = ItemsControl.ItemsControlFromItemContainer(item);
+
+                    if (itemParent != null)
+                    {
+                        this.SourceCollection = itemParent.ItemsSource ?? itemParent.Items;
+                        if (itemParent != itemsControl)
+                        {
+                            var tvItem = item as TreeViewItem;
+                            if (tvItem != null)
+                            {
+                                var tv = tvItem.GetVisualAncestor<TreeView>();
+                                if (tv != null && tv != itemsControl && !tv.IsDragSource())
+                                {
+                                    return;
+                                }
+                            }
+                            else if (itemsControl.ItemContainerGenerator.IndexFromContainer(itemParent) < 0 && !itemParent.IsDragSource())
+                            {
+                                return;
+                            }
+                        }
+                        this.SourceIndex = itemParent.ItemContainerGenerator.IndexFromContainer(item);
+                        this.SourceItem = itemParent.ItemContainerGenerator.ItemFromContainer(item);
+                    }
+                    else
+                    {
+                        this.SourceIndex = -1;
+                    }
+
+                    var selectedItems = itemsControl.GetSelectedItems().OfType<object>().Where(i => i != CollectionView.NewItemPlaceholder).ToList();
+                    this.SourceItems = selectedItems;
+
+                    // Some controls (I'm looking at you TreeView!) haven't updated their
+                    // SelectedItem by this point. Check to see if there 1 or less item in 
+                    // the SourceItems collection, and if so, override the control's SelectedItems with the clicked item.
+                    //
+                    // The control has still the old selected items at the mouse down event, so we should check this and give only the real selected item to the user.
+                    if (selectedItems.Count <= 1 || this.SourceItem != null && !selectedItems.Contains(this.SourceItem))
+                    {
+                        this.SourceItems = Enumerable.Repeat(this.SourceItem, 1);
+                    }
+
+                    this.VisualSourceItem = item;
+                }
+                else
+                {
+                    this.SourceCollection = itemsControl.ItemsSource ?? itemsControl.Items;
+                }
+            }
+            else
+            {
+                this.SourceItem = (sender as FrameworkElement)?.DataContext;
+                if (this.SourceItem != null)
+                {
+                    this.SourceItems = Enumerable.Repeat(this.SourceItem, 1);
+                }
+                this.VisualSourceItem = sourceElement;
+                this.PositionInDraggedItem = sourceElement != null ? getPosition(sourceElement) : this.DragStartPosition;
+            }
+
+            if (this.SourceItems == null)
+            {
+                this.SourceItems = Enumerable.Empty<object>();
+            }
+        }
     }
 }

--- a/src/GongSolutions.WPF.DragDrop/DragInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragInfo.cs
@@ -33,12 +33,24 @@ namespace GongSolutions.Wpf.DragDrop
         /// </param>
         public DragInfo(object sender, MouseButtonEventArgs e)
         {
-            InitializeDragInfo(sender, e.OriginalSource, (item) => e.GetPosition(item));
+            this.InitializeDragInfo(sender, e.OriginalSource, item => e.GetPosition(item));
+            this.MouseButton = e.ChangedButton;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the DragInfo class.
+        /// </summary>
+        /// 
+        /// <param name="sender">
+        /// The sender of the mouse event that initiated the drag.
+        /// </param>
+        /// 
+        /// <param name="e">
+        /// The touch event that initiated the drag.
+        /// </param>
         public DragInfo(object sender, TouchEventArgs e)
         {
-            InitializeDragInfo(sender, e.OriginalSource, (item) => e.GetTouchPoint(item).Position);
+            this.InitializeDragInfo(sender, e.OriginalSource, item => e.GetTouchPoint(item).Position);
         }
 
         internal void RefreshSelectedItems(object sender)
@@ -116,7 +128,6 @@ namespace GongSolutions.Wpf.DragDrop
         private void InitializeDragInfo(object sender, object originalSource, Func<IInputElement, Point> getPosition)
         {
             this.Effects = DragDropEffects.None;
-            this.MouseButton = MouseButton.Left;
             this.VisualSource = sender as UIElement;
             this.DragStartPosition = getPosition(this.VisualSource);
             this.DragDropCopyKeyState = DragDrop.GetDragDropCopyKeyState(this.VisualSource);

--- a/src/GongSolutions.WPF.DragDrop/Utilities/HitTestUtilities.cs
+++ b/src/GongSolutions.WPF.DragDrop/Utilities/HitTestUtilities.cs
@@ -98,12 +98,23 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
         /// </summary>
         public static bool IsNotPartOfSender(object sender, MouseButtonEventArgs e)
         {
-            var visual = e.OriginalSource as Visual;
+            return IsNotPartOfSender(sender, e.OriginalSource, e.GetPosition((IInputElement)e.OriginalSource));
+        }
+
+        public static bool IsNotPartOfSender(object sender, TouchEventArgs e)
+        {
+            return IsNotPartOfSender(sender, e.OriginalSource, e.GetTouchPoint((IInputElement)e.OriginalSource).Position);
+        }
+
+        private static bool IsNotPartOfSender(object sender, object originalSource, Point position)
+        {
+            var visual = originalSource as Visual;
+
             if (visual == null)
             {
                 return false;
             }
-            var hit = VisualTreeHelper.HitTest(visual, e.GetPosition((IInputElement)visual));
+            var hit = VisualTreeHelper.HitTest(visual, position);
 
             if (hit == null)
             {
@@ -111,7 +122,7 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
             }
             else
             {
-                var depObj = e.OriginalSource as DependencyObject;
+                var depObj = originalSource as DependencyObject;
                 if (depObj == null)
                 {
                     return false;


### PR DESCRIPTION
## What changed?

The goal of this PR was to implement the feature "Touch drag & drop" that is linked to the old issue #110. Now we can do a drag and drop with a touch screen without doing the workaround presented in the issue.

We add the three events `PreviewTouchDown`, `PreviewTouchUp` and `PreviewTouchMove` where we do approximatively the same stuff as for the mouse events.
The way to get the position is different between the mouse and the touch, so we need to change some methods so that they can accept a `TouchEventArgs` and not only a `MouseButtonEventArgs`. We needed to change the `DragInfo` constructor so that we can initialize the object with both events.