### PR TITLE
Fix scrolling issues if ScrollViewer CanContentScroll is set true

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/DragAdorner.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragAdorner.cs
@@ -15,8 +15,6 @@ namespace GongSolutions.Wpf.DragDrop
             this.m_Adornment = adornment;
             this.IsHitTestVisible = false;
             this.Effects = effects;
-            // another flicker fix
-            this.UpdateLayout();
         }
 
         public Point Translation { get; private set; }
@@ -25,7 +23,7 @@ namespace GongSolutions.Wpf.DragDrop
 
         public Point MousePosition
         {
-            get { return this.m_MousePosition; }
+            get => this.m_MousePosition;
             set
             {
                 if (this.m_MousePosition != value)
@@ -121,10 +119,7 @@ namespace GongSolutions.Wpf.DragDrop
             return this.m_Adornment.DesiredSize;
         }
 
-        protected override int VisualChildrenCount
-        {
-            get { return 1; }
-        }
+        protected override int VisualChildrenCount => 1;
 
         private readonly AdornerLayer m_AdornerLayer;
         private readonly UIElement m_Adornment;

--- a/src/GongSolutions.WPF.DragDrop/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.cs
@@ -219,11 +219,25 @@ namespace GongSolutions.Wpf.DragDrop
             {
                 if (position.X >= scrollViewer.ActualWidth - scrollMargin && scrollViewer.HorizontalOffset < scrollViewer.ExtentWidth - scrollViewer.ViewportWidth)
                 {
-                    scrollViewer.LineRight();
+                    if (scrollViewer.CanContentScroll)
+                    {
+                        scrollViewer.LineRight();
+                    }
+                    else
+                    {
+                        scrollViewer.ScrollToHorizontalOffset(scrollViewer.HorizontalOffset + 4);
+                    }
                 }
                 else if (position.X < scrollMargin && scrollViewer.HorizontalOffset > 0)
                 {
-                    scrollViewer.LineLeft();
+                    if (scrollViewer.CanContentScroll)
+                    {
+                        scrollViewer.LineLeft();
+                    }
+                    else
+                    {
+                        scrollViewer.ScrollToHorizontalOffset(scrollViewer.HorizontalOffset - 4);
+                    }
                 }
             }
 
@@ -231,11 +245,25 @@ namespace GongSolutions.Wpf.DragDrop
             {
                 if (position.Y >= scrollViewer.ActualHeight - scrollMargin && scrollViewer.VerticalOffset < scrollViewer.ExtentHeight - scrollViewer.ViewportHeight)
                 {
-                    scrollViewer.LineDown();
+                    if (scrollViewer.CanContentScroll)
+                    {
+                        scrollViewer.LineDown();
+                    }
+                    else
+                    {
+                        scrollViewer.ScrollToVerticalOffset(scrollViewer.VerticalOffset + 4);
+                    }
                 }
                 else if (position.Y < scrollMargin && scrollViewer.VerticalOffset > 0)
                 {
-                    scrollViewer.LineUp();
+                    if (scrollViewer.CanContentScroll)
+                    {
+                        scrollViewer.LineUp();
+                    }
+                    else
+                    {
+                        scrollViewer.ScrollToVerticalOffset(scrollViewer.VerticalOffset - 4);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Use ScrollToHorizontalOffset and ScrollToVerticalOffset instead the LineLeft, LineRight, LineUp and LineDown methods to prevent a scrolling issue with the Adorners.

This was reported by @KeithSwanger on Gitter channel.

![EZyn2V2](https://user-images.githubusercontent.com/658431/96353563-8a537f00-10cd-11eb-9d92-37674670069f.gif)
