### PR TITLE
Fixed namespace issues

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/DefaultDropHandler.cs
+++ b/src/GongSolutions.WPF.DragDrop/DefaultDropHandler.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
 using GongSolutions.Wpf.DragDrop.Utilities;

--- a/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
@@ -1,9 +1,9 @@
-﻿using GongSolutions.WPF.DragDrop.Utilities;
-using System;
+﻿using System;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
+using GongSolutions.Wpf.DragDrop.Utilities;
 
 namespace GongSolutions.Wpf.DragDrop
 {

--- a/src/GongSolutions.WPF.DragDrop/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.cs
@@ -9,7 +9,6 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using GongSolutions.Wpf.DragDrop.Icons;
 using GongSolutions.Wpf.DragDrop.Utilities;
-using GongSolutions.WPF.DragDrop.Utilities;
 
 namespace GongSolutions.Wpf.DragDrop
 {

--- a/src/GongSolutions.WPF.DragDrop/DropTargetHighlightAdorner.cs
+++ b/src/GongSolutions.WPF.DragDrop/DropTargetHighlightAdorner.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 

--- a/src/GongSolutions.WPF.DragDrop/GongSolutions.WPF.DragDrop.csproj
+++ b/src/GongSolutions.WPF.DragDrop/GongSolutions.WPF.DragDrop.csproj
@@ -4,7 +4,7 @@
     <PropertyGroup>
         <AssemblyName>GongSolutions.WPF.DragDrop</AssemblyName>
         <Title>gong-wpf-dragdrop</Title>
-        <RootNamespace>GongSolutions.WPF.DragDrop</RootNamespace>
+        <RootNamespace>GongSolutions.Wpf.DragDrop</RootNamespace>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
     <!-- reference includes -->

--- a/src/GongSolutions.WPF.DragDrop/Utilities/IRootElementFinder.cs
+++ b/src/GongSolutions.WPF.DragDrop/Utilities/IRootElementFinder.cs
@@ -1,6 +1,6 @@
 ﻿using System.Windows;
 
-namespace GongSolutions.WPF.DragDrop.Utilities
+namespace GongSolutions.Wpf.DragDrop.Utilities
 {
     /// <summary>
     /// Interface implemented by the root element finder.

--- a/src/GongSolutions.WPF.DragDrop/Utilities/RootElementFinder.cs
+++ b/src/GongSolutions.WPF.DragDrop/Utilities/RootElementFinder.cs
@@ -1,5 +1,4 @@
-﻿using GongSolutions.WPF.DragDrop.Utilities;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
 
 namespace GongSolutions.Wpf.DragDrop.Utilities


### PR DESCRIPTION
## What changed?

I fixed some namespace issues.

The new `IRootElementFinder` used a different namespace than the rest of the project, due to capitalizing WPF. I changed the `RootNamespace` in the project file so that this shouldn't happen again in the future.

Also removed a couple of using directives that were not required.
