### PR TITLE
Fix DpiHelper usage

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <!-- Project properties -->
     <PropertyGroup>
-        <TargetFrameworks>net45;net46;net47;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net45;net46;net462;net47;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
         <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
         <AutoGenerateBindingRedirects Condition=" $(TargetFramework.StartsWith('net4')) ">true</AutoGenerateBindingRedirects>

--- a/src/GongSolutions.WPF.DragDrop/Utilities/DpiHelper.cs
+++ b/src/GongSolutions.WPF.DragDrop/Utilities/DpiHelper.cs
@@ -1,18 +1,89 @@
-﻿namespace GongSolutions.Wpf.DragDrop.Utilities
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Windows;
+using System.Windows.Media;
+
+namespace GongSolutions.Wpf.DragDrop.Utilities
 {
-    using System.Diagnostics.CodeAnalysis;
+#if NET461 || NET46 || NET452 || NET451 || NET45
     using System.Reflection;
-    using System.Windows;
-    using System.Windows.Media;
+#endif
 
     /// <summary>
     /// A helper class for Dpi logicm cause Microsoft hides this with the internal flag.
     /// </summary>
     public static class DpiHelper
     {
+        [ThreadStatic]
         private static Matrix _transformToDevice;
-        private static Matrix _transformToLogical;
+        [ThreadStatic]
+        private static Matrix _transformToDip;
 
+        /// <summary>
+        /// Convert a point in device independent pixels (1/96") to a point in the system coordinates.
+        /// </summary>
+        /// <param name="logicalPoint">A point in the logical coordinate system.</param>
+        /// <returns>Returns the parameter converted to the system's coordinates.</returns>
+        public static Point LogicalPixelsToDevice(Point logicalPoint, double dpiScaleX, double dpiScaleY)
+        {
+            _transformToDevice = Matrix.Identity;
+            _transformToDevice.Scale(dpiScaleX, dpiScaleY);
+            return _transformToDevice.Transform(logicalPoint);
+        }
+
+        /// <summary>
+        /// Convert a point in system coordinates to a point in device independent pixels (1/96").
+        /// </summary>
+        /// <param name="devicePoint">A point in the physical coordinate system.</param>
+        /// <returns>Returns the parameter converted to the device independent coordinate system.</returns>
+        public static Point DevicePixelsToLogical(Point devicePoint, double dpiScaleX, double dpiScaleY)
+        {
+            _transformToDip = Matrix.Identity;
+            _transformToDip.Scale(1d / dpiScaleX, 1d / dpiScaleY);
+            return _transformToDip.Transform(devicePoint);
+        }
+
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        public static Rect LogicalRectToDevice(Rect logicalRectangle, double dpiScaleX, double dpiScaleY)
+        {
+            Point topLeft = LogicalPixelsToDevice(new Point(logicalRectangle.Left, logicalRectangle.Top), dpiScaleX, dpiScaleY);
+            Point bottomRight = LogicalPixelsToDevice(new Point(logicalRectangle.Right, logicalRectangle.Bottom), dpiScaleX, dpiScaleY);
+
+            return new Rect(topLeft, bottomRight);
+        }
+
+        public static Rect DeviceRectToLogical(Rect deviceRectangle, double dpiScaleX, double dpiScaleY)
+        {
+            Point topLeft = DevicePixelsToLogical(new Point(deviceRectangle.Left, deviceRectangle.Top), dpiScaleX, dpiScaleY);
+            Point bottomRight = DevicePixelsToLogical(new Point(deviceRectangle.Right, deviceRectangle.Bottom), dpiScaleX, dpiScaleY);
+
+            return new Rect(topLeft, bottomRight);
+        }
+
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        public static Size LogicalSizeToDevice(Size logicalSize, double dpiScaleX, double dpiScaleY)
+        {
+            Point pt = LogicalPixelsToDevice(new Point(logicalSize.Width, logicalSize.Height), dpiScaleX, dpiScaleY);
+
+            return new Size { Width = pt.X, Height = pt.Y };
+        }
+
+        public static Size DeviceSizeToLogical(Size deviceSize, double dpiScaleX, double dpiScaleY)
+        {
+            Point pt = DevicePixelsToLogical(new Point(deviceSize.Width, deviceSize.Height), dpiScaleX, dpiScaleY);
+
+            return new Size(pt.X, pt.Y);
+        }
+
+        public static Thickness LogicalThicknessToDevice(Thickness logicalThickness, double dpiScaleX, double dpiScaleY)
+        {
+            Point topLeft = LogicalPixelsToDevice(new Point(logicalThickness.Left, logicalThickness.Top), dpiScaleX, dpiScaleY);
+            Point bottomRight = LogicalPixelsToDevice(new Point(logicalThickness.Right, logicalThickness.Bottom), dpiScaleX, dpiScaleY);
+
+            return new Thickness(topLeft.X, topLeft.Y, bottomRight.X, bottomRight.Y);
+        }
+
+#if NET461 || NET46 || NET452 || NET451 || NET45
         public static double DpiX = 0d;
         public static double DpiY = 0d;
 
@@ -22,15 +93,10 @@
             var dpiXProperty = typeof(SystemParameters).GetProperty("DpiX", BindingFlags.NonPublic | BindingFlags.Static);
             var dpiYProperty = typeof(SystemParameters).GetProperty("Dpi", BindingFlags.NonPublic | BindingFlags.Static);
 
-            var pixelsPerInchX = (int)dpiXProperty.GetValue(null, null); //SystemParameters.DpiX;
+            var pixelsPerInchX = (int)dpiXProperty.GetValue(null, null);
             DpiX = (double)pixelsPerInchX;
-            var pixelsPerInchY = (int)dpiYProperty.GetValue(null, null); //SystemParameters.Dpi;
+            var pixelsPerInchY = (int)dpiYProperty.GetValue(null, null);
             DpiY = (double)pixelsPerInchY;
-
-            _transformToLogical = Matrix.Identity;
-            _transformToLogical.Scale(96d / (double)pixelsPerInchX, 96d / (double)pixelsPerInchY);
-            _transformToDevice = Matrix.Identity;
-            _transformToDevice.Scale((double)pixelsPerInchX / 96d, (double)pixelsPerInchY / 96d);
         }
 
         /// <summary>
@@ -40,7 +106,7 @@
         /// <returns>Returns the point converted to the system's coordinates.</returns>
         public static Point LogicalPixelsToDevice(Point logicalPoint)
         {
-            return _transformToDevice.Transform(logicalPoint);
+            return LogicalPixelsToDevice(logicalPoint, DpiX / 96d, DpiY / 96d);
         }
 
         /// <summary>
@@ -50,7 +116,7 @@
         /// <returns>Returns the point converted to the device independent coordinate system.</returns>
         public static Point DevicePixelsToLogical(Point devicePoint)
         {
-            return _transformToLogical.Transform(devicePoint);
+            return DevicePixelsToLogical(devicePoint, 96d / DpiX, 96d / DpiY);
         }
 
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
@@ -92,5 +158,6 @@
 
             return new Thickness(topLeft.X, topLeft.Y, bottomRight.X, bottomRight.Y);
         }
+#endif
     }
 }

--- a/src/GongSolutions.WPF.DragDrop/Utilities/DragDropExtensions.cs
+++ b/src/GongSolutions.WPF.DragDrop/Utilities/DragDropExtensions.cs
@@ -1,12 +1,11 @@
+using System;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Media;
+using System.Windows.Media.Imaging;
 
 namespace GongSolutions.Wpf.DragDrop.Utilities
 {
-    using System;
-    using System.Windows.Controls;
-    using System.Windows.Media.Imaging;
-
     public static class DragDropExtensions
     {
         /// <summary>
@@ -38,7 +37,7 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
         {
             return element != null && DragDrop.GetIsDropTarget(element);
         }
-        
+
         /// <summary>
         /// Gets if drop position is directly over element
         /// </summary>
@@ -53,7 +52,7 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
 
             var relativeItemPosition = element.TranslatePoint(new Point(0, 0), relativeToElement);
             var relativeDropPosition = new Point(dropPosition.X - relativeItemPosition.X, dropPosition.Y - relativeItemPosition.Y);
-            return VisualTreeHelper.GetDescendantBounds(element).Contains(relativeDropPosition); 
+            return VisualTreeHelper.GetDescendantBounds(element).Contains(relativeDropPosition);
         }
 
         /// <summary>
@@ -78,6 +77,7 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
                 factory.SetValue(FrameworkElement.VerticalAlignmentProperty, VerticalAlignment.Top);
                 template = new DataTemplate { VisualTree = factory };
             }
+
             return template;
         }
 
@@ -90,11 +90,20 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
                 return null;
             }
 
+            var bounds = VisualTreeHelper.GetDescendantBounds(target);
+
+#if NET461 || NET46 || NET452 || NET451 || NET45
             var dpiX = DpiHelper.DpiX;
             var dpiY = DpiHelper.DpiY;
 
-            var bounds = VisualTreeHelper.GetDescendantBounds(target);
             var dpiBounds = DpiHelper.LogicalRectToDevice(bounds);
+#else
+            var dpiScale = VisualTreeHelper.GetDpi(target);
+            var dpiX = dpiScale.PixelsPerInchX;
+            var dpiY = dpiScale.PixelsPerInchY;
+
+            var dpiBounds = DpiHelper.LogicalRectToDevice(bounds, dpiScale.DpiScaleX, dpiScale.DpiScaleY);
+#endif
 
             var pixelWidth = (int)Math.Ceiling(dpiBounds.Width);
             var pixelHeight = (int)Math.Ceiling(dpiBounds.Height);
@@ -116,6 +125,7 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
                     transformGroup.Children.Add(new TranslateTransform(bounds.Size.Width - 1, 0));
                     ctx.PushTransform(transformGroup);
                 }
+
                 ctx.DrawRectangle(vb, null, new Rect(new Point(), bounds.Size));
             }
 

--- a/src/Showcase/App.net462.config
+++ b/src/Showcase/App.net462.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
+    </startup>
+</configuration>


### PR DESCRIPTION
## What changed?

Use VisualTreeHelper.GetDpi for newer frameworks (>= .Net 4.6.2)
