### PR TITLE
Fix testing of DragSourceIgnored for an item if DragDirectlySelectedOnly is set to false

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/DragInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragInfo.cs
@@ -167,6 +167,11 @@ namespace GongSolutions.Wpf.DragDrop
                     else
                     {
                         item = itemsControl.GetItemContainerAt(itemPosition, itemsControl.GetItemsPanelOrientation());
+
+                        if (item.IsDragSourceIgnored())
+                        {
+                            item = null;
+                        }
                     }
                 }
 


### PR DESCRIPTION
## What changed?

Fix testing of DragSourceIgnored for an item if DragDirectlySelectedOnly is set to false.

Closes #350 
