### PR TITLE
Feature: sort drag drop preview items

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
@@ -1154,21 +1154,22 @@ namespace GongSolutions.Wpf.DragDrop
         /// </summary>
         public static readonly DependencyProperty DragSortHandlerProperty
             = DependencyProperty.RegisterAttached("DragSortHandler",
-                                                typeof(IDragEnumerableSorter),
-                                                typeof(DragDrop));
+                                                  typeof(IDragPreviewItemsSorter),
+                                                  typeof(DragDrop),
+                                                  new PropertyMetadata(null));
 
         /// <summary>
         /// Get the dragged items sorter handler
         /// </summary>
-        public static IDragEnumerableSorter GetDragSortHandler(UIElement target)
+        public static IDragPreviewItemsSorter GetDragSortHandler(UIElement target)
         {
-            return (IDragEnumerableSorter)target.GetValue(DragSortHandlerProperty);
+            return (IDragPreviewItemsSorter)target.GetValue(DragSortHandlerProperty);
         }
 
         /// <summary>
         /// Sets the handler for the dragged items sorter
         /// </summary>
-        public static void SetDragSortHandler(UIElement target, IDragEnumerableSorter value)
+        public static void SetDragSortHandler(UIElement target, IDragPreviewItemsSorter value)
         {
             target.SetValue(DragSortHandlerProperty, value);
         }

--- a/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
@@ -1152,8 +1152,8 @@ namespace GongSolutions.Wpf.DragDrop
         /// <summary>
         /// Gets or sets the handler for the dragged items sorter
         /// </summary>
-        public static readonly DependencyProperty DragSortHandlerProperty
-            = DependencyProperty.RegisterAttached("DragSortHandler",
+        public static readonly DependencyProperty DragPreviewSortHandlerProperty
+            = DependencyProperty.RegisterAttached("DragPreviewSortHandler",
                                                   typeof(IDragPreviewItemsSorter),
                                                   typeof(DragDrop),
                                                   new PropertyMetadata(null));
@@ -1161,17 +1161,17 @@ namespace GongSolutions.Wpf.DragDrop
         /// <summary>
         /// Get the dragged items sorter handler
         /// </summary>
-        public static IDragPreviewItemsSorter GetDragSortHandler(UIElement target)
+        public static IDragPreviewItemsSorter GetDragPreviewSortHandler(UIElement target)
         {
-            return (IDragPreviewItemsSorter)target.GetValue(DragSortHandlerProperty);
+            return (IDragPreviewItemsSorter)target.GetValue(DragPreviewSortHandlerProperty);
         }
 
         /// <summary>
         /// Sets the handler for the dragged items sorter
         /// </summary>
-        public static void SetDragSortHandler(UIElement target, IDragPreviewItemsSorter value)
+        public static void SetDragPreviewSortHandler(UIElement target, IDragPreviewItemsSorter value)
         {
-            target.SetValue(DragSortHandlerProperty, value);
+            target.SetValue(DragPreviewSortHandlerProperty, value);
         }
     }
 }

--- a/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
@@ -1150,28 +1150,28 @@ namespace GongSolutions.Wpf.DragDrop
         }
 
         /// <summary>
-        /// Gets or sets the handler for the dragged items sorter
+        /// Gets or sets the handler for the dragged preview items sorter
         /// </summary>
-        public static readonly DependencyProperty DragPreviewSortHandlerProperty
-            = DependencyProperty.RegisterAttached("DragPreviewSortHandler",
+        public static readonly DependencyProperty DragPreviewItemsSorterProperty
+            = DependencyProperty.RegisterAttached("DragPreviewItemsSorter",
                                                   typeof(IDragPreviewItemsSorter),
                                                   typeof(DragDrop),
                                                   new PropertyMetadata(null));
 
         /// <summary>
-        /// Get the dragged items sorter handler
+        /// Get the dragged preview items sorter handler
         /// </summary>
-        public static IDragPreviewItemsSorter GetDragPreviewSortHandler(UIElement target)
+        public static IDragPreviewItemsSorter GetDragPreviewItemsSorter(UIElement target)
         {
-            return (IDragPreviewItemsSorter)target.GetValue(DragPreviewSortHandlerProperty);
+            return (IDragPreviewItemsSorter)target.GetValue(DragPreviewItemsSorterProperty);
         }
 
         /// <summary>
-        /// Sets the handler for the dragged items sorter
+        /// Sets the handler for the dragged preview items sorter
         /// </summary>
-        public static void SetDragPreviewSortHandler(UIElement target, IDragPreviewItemsSorter value)
+        public static void SetDragPreviewItemsSorter(UIElement target, IDragPreviewItemsSorter value)
         {
-            target.SetValue(DragPreviewSortHandlerProperty, value);
+            target.SetValue(DragPreviewItemsSorterProperty, value);
         }
     }
 }

--- a/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
@@ -1148,5 +1148,29 @@ namespace GongSolutions.Wpf.DragDrop
         {
             target.SetValue(RootElementFinderProperty, value);
         }
+
+        /// <summary>
+        /// Gets or sets the handler for the dragged items sorter
+        /// </summary>
+        public static readonly DependencyProperty DragSortHandlerProperty
+            = DependencyProperty.RegisterAttached("DragSortHandler",
+                                                typeof(IDragEnumerableSorter),
+                                                typeof(DragDrop));
+
+        /// <summary>
+        /// Get the dragged items sorter handler
+        /// </summary>
+        public static IDragEnumerableSorter GetDragSortHandler(UIElement target)
+        {
+            return (IDragEnumerableSorter)target.GetValue(DragSortHandlerProperty);
+        }
+
+        /// <summary>
+        /// Sets the handler for the dragged items sorter
+        /// </summary>
+        public static void SetDragSortHandler(UIElement target, IDragEnumerableSorter value)
+        {
+            target.SetValue(DragSortHandlerProperty, value);
+        }
     }
 }

--- a/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
@@ -1159,7 +1159,7 @@ namespace GongSolutions.Wpf.DragDrop
                                                   new PropertyMetadata(null));
 
         /// <summary>
-        /// Get the dragged preview items sorter handler
+        /// Get the drag preview items sorter handler
         /// </summary>
         public static IDragPreviewItemsSorter GetDragPreviewItemsSorter(UIElement target)
         {
@@ -1167,7 +1167,7 @@ namespace GongSolutions.Wpf.DragDrop
         }
 
         /// <summary>
-        /// Sets the handler for the dragged preview items sorter
+        /// Sets the handler for the drag preview items sorter
         /// </summary>
         public static void SetDragPreviewItemsSorter(UIElement target, IDragPreviewItemsSorter value)
         {
@@ -1175,7 +1175,7 @@ namespace GongSolutions.Wpf.DragDrop
         }
 
         /// <summary>
-        /// Gets or sets the handler for the dragged preview items sorter
+        /// Gets or sets the handler for the drop target items sorter
         /// </summary>
         public static readonly DependencyProperty DropTargetItemsSorterProperty
             = DependencyProperty.RegisterAttached("DropTargetItemsSorter",

--- a/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
@@ -1173,5 +1173,30 @@ namespace GongSolutions.Wpf.DragDrop
         {
             target.SetValue(DragPreviewItemsSorterProperty, value);
         }
+
+        /// <summary>
+        /// Gets or sets the handler for the dragged preview items sorter
+        /// </summary>
+        public static readonly DependencyProperty DropTargetItemsSorterProperty
+            = DependencyProperty.RegisterAttached("DropTargetItemsSorter",
+                                                  typeof(IDropTargetItemsSorter),
+                                                  typeof(DragDrop),
+                                                  new PropertyMetadata(null));
+
+        /// <summary>
+        /// Get the drop target items sorter handler
+        /// </summary>
+        public static IDropTargetItemsSorter GetDropTargetItemsSorter(UIElement target)
+        {
+            return (IDropTargetItemsSorter)target.GetValue(DropTargetItemsSorterProperty);
+        }
+
+        /// <summary>
+        /// Sets the handler for the drop target items sorter
+        /// </summary>
+        public static void SetDropTargetItemsSorter(UIElement target, IDropTargetItemsSorter value)
+        {
+            target.SetValue(DropTargetItemsSorterProperty, value);
+        }
     }
 }

--- a/src/GongSolutions.WPF.DragDrop/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.cs
@@ -43,15 +43,7 @@ namespace GongSolutions.Wpf.DragDrop
                         var sorter = TryGetDragPreviewItemsSorter(dragInfo, target);
                         if (sorter != null)
                         {
-                            try
-                            {
-                                itemsControl.ItemsSource = sorter.SortDragPreviewItems(itemsControl.ItemsSource);
-                            }
-                            catch 
-                            { 
-                                // Silently ignore any sorting exceptions -- better to let the drag & drop continue
-                                // as sorting is not required in order to finish the drag & drop operation
-                            }
+                            itemsControl.ItemsSource = sorter.SortDragPreviewItems(itemsControl.ItemsSource);
                         }
                         
                         itemsControl.ItemTemplate = template;
@@ -783,15 +775,7 @@ namespace GongSolutions.Wpf.DragDrop
             dropHandler.DragOver(dropInfo);
             if (dropTargetSorterHandler != null && dropInfo.Data is IEnumerable enumerable)
             {
-                try
-                {
-                    dropInfo.Data = dropTargetSorterHandler.SortDropTargetItems(enumerable);
-                }
-                catch
-                {
-                    // Silently ignore any sorting exceptions -- better to let the drag & drop continue
-                    // as sorting is not required in order to finish the drag & drop operation
-                }
+                dropInfo.Data = dropTargetSorterHandler.SortDropTargetItems(enumerable);
             }
             dropHandler.Drop(dropInfo);
             dragHandler.Dropped(dropInfo);

--- a/src/GongSolutions.WPF.DragDrop/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.cs
@@ -43,7 +43,15 @@ namespace GongSolutions.Wpf.DragDrop
                         var sorter = TryGetDragPreviewItemsSorter(dragInfo, target);
                         if (sorter != null)
                         {
-                            itemsControl.ItemsSource = sorter.SortDragPreviewItems(itemsControl.ItemsSource);
+                            try
+                            {
+                                itemsControl.ItemsSource = sorter.SortDragPreviewItems(itemsControl.ItemsSource);
+                            }
+                            catch 
+                            { 
+                                // Silently ignore any sorting exceptions -- better to let the drag & drop continue
+                                // as sorting is not required in order to finish the drag & drop operation
+                            }
                         }
                         
                         itemsControl.ItemTemplate = template;
@@ -775,7 +783,15 @@ namespace GongSolutions.Wpf.DragDrop
             dropHandler.DragOver(dropInfo);
             if (dropTargetSorterHandler != null && dropInfo.Data is IEnumerable enumerable)
             {
-                dropInfo.Data = dropTargetSorterHandler.SortDropTargetItems(enumerable);
+                try
+                {
+                    dropInfo.Data = dropTargetSorterHandler.SortDropTargetItems(enumerable);
+                }
+                catch
+                {
+                    // Silently ignore any sorting exceptions -- better to let the drag & drop continue
+                    // as sorting is not required in order to finish the drag & drop operation
+                }
             }
             dropHandler.Drop(dropInfo);
             dragHandler.Dropped(dropInfo);

--- a/src/GongSolutions.WPF.DragDrop/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.cs
@@ -38,6 +38,14 @@ namespace GongSolutions.Wpf.DragDrop
                     {
                         var itemsControl = new ItemsControl();
                         itemsControl.ItemsSource = (IEnumerable)dragInfo.Data;
+
+                        // sort items if necessary before creating the preview
+                        var sorter = TryGetAdornerSorter(dragInfo, target);
+                        if (sorter != null)
+                        {
+                            itemsControl.ItemsSource = sorter.SortDragDropItems(itemsControl.ItemsSource);
+                        }
+                        
                         itemsControl.ItemTemplate = template;
                         itemsControl.ItemTemplateSelector = templateSelector;
                         itemsControl.Tag = dragInfo;
@@ -302,6 +310,20 @@ namespace GongSolutions.Wpf.DragDrop
             }
 
             return rootElementFinder ?? new RootElementFinder();
+        }
+
+        private static IDragEnumerableSorter TryGetAdornerSorter(IDragInfo info, UIElement sender)
+        {
+            IDragEnumerableSorter handler = null;
+            if (info != null && info.VisualSource != null)
+            {
+                handler = (IDragEnumerableSorter)info.VisualSource.GetValue(DragDrop.DragSortHandlerProperty);
+            }
+            if (handler == null && sender != null)
+            {
+                handler = (IDragEnumerableSorter)sender.GetValue(DragDrop.DragSortHandlerProperty);
+            }
+            return handler ?? null;
         }
 
         private static void DragSourceOnMouseLeftButtonDown(object sender, MouseButtonEventArgs e)

--- a/src/GongSolutions.WPF.DragDrop/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.cs
@@ -40,7 +40,7 @@ namespace GongSolutions.Wpf.DragDrop
                         itemsControl.ItemsSource = (IEnumerable)dragInfo.Data;
 
                         // sort items if necessary before creating the preview
-                        var sorter = TryGetDragPreviewSorter(dragInfo, target);
+                        var sorter = TryGetDragPreviewItemsSorter(dragInfo, target);
                         if (sorter != null)
                         {
                             itemsControl.ItemsSource = sorter.SortDragDropItems(itemsControl.ItemsSource);
@@ -312,16 +312,16 @@ namespace GongSolutions.Wpf.DragDrop
             return rootElementFinder ?? new RootElementFinder();
         }
 
-        private static IDragPreviewItemsSorter TryGetDragPreviewSorter(IDragInfo dragInfo, UIElement sender)
+        private static IDragPreviewItemsSorter TryGetDragPreviewItemsSorter(IDragInfo dragInfo, UIElement sender)
         {
             IDragPreviewItemsSorter handler = null;
             if (dragInfo != null && dragInfo.VisualSource != null)
             {
-                handler = GetDragPreviewSortHandler(dragInfo.VisualSource);
+                handler = GetDragPreviewItemsSorter(dragInfo.VisualSource);
             }
             if (handler == null && sender != null)
             {
-                handler = GetDragPreviewSortHandler(sender);
+                handler = GetDragPreviewItemsSorter(sender);
             }
 
             return handler;

--- a/src/GongSolutions.WPF.DragDrop/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.cs
@@ -40,7 +40,7 @@ namespace GongSolutions.Wpf.DragDrop
                         itemsControl.ItemsSource = (IEnumerable)dragInfo.Data;
 
                         // sort items if necessary before creating the preview
-                        var sorter = TryGetAdornerSorter(dragInfo, target);
+                        var sorter = TryGetDragPreviewSorter(dragInfo, target);
                         if (sorter != null)
                         {
                             itemsControl.ItemsSource = sorter.SortDragDropItems(itemsControl.ItemsSource);
@@ -312,16 +312,16 @@ namespace GongSolutions.Wpf.DragDrop
             return rootElementFinder ?? new RootElementFinder();
         }
 
-        private static IDragEnumerableSorter TryGetAdornerSorter(IDragInfo info, UIElement sender)
+        private static IDragPreviewItemsSorter TryGetDragPreviewSorter(IDragInfo info, UIElement sender)
         {
-            IDragEnumerableSorter handler = null;
+            IDragPreviewItemsSorter handler = null;
             if (info != null && info.VisualSource != null)
             {
-                handler = (IDragEnumerableSorter)info.VisualSource.GetValue(DragDrop.DragSortHandlerProperty);
+                handler = (IDragPreviewItemsSorter)info.VisualSource.GetValue(DragDrop.DragSortHandlerProperty);
             }
             if (handler == null && sender != null)
             {
-                handler = (IDragEnumerableSorter)sender.GetValue(DragDrop.DragSortHandlerProperty);
+                handler = (IDragPreviewItemsSorter)sender.GetValue(DragDrop.DragSortHandlerProperty);
             }
             return handler ?? null;
         }

--- a/src/GongSolutions.WPF.DragDrop/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.cs
@@ -312,18 +312,19 @@ namespace GongSolutions.Wpf.DragDrop
             return rootElementFinder ?? new RootElementFinder();
         }
 
-        private static IDragPreviewItemsSorter TryGetDragPreviewSorter(IDragInfo info, UIElement sender)
+        private static IDragPreviewItemsSorter TryGetDragPreviewSorter(IDragInfo dragInfo, UIElement sender)
         {
             IDragPreviewItemsSorter handler = null;
-            if (info != null && info.VisualSource != null)
+            if (dragInfo != null && dragInfo.VisualSource != null)
             {
-                handler = (IDragPreviewItemsSorter)info.VisualSource.GetValue(DragDrop.DragSortHandlerProperty);
+                handler = GetDragPreviewSortHandler(dragInfo.VisualSource);
             }
             if (handler == null && sender != null)
             {
-                handler = (IDragPreviewItemsSorter)sender.GetValue(DragDrop.DragSortHandlerProperty);
+                handler = GetDragPreviewSortHandler(sender);
             }
-            return handler ?? null;
+
+            return handler;
         }
 
         private static void DragSourceOnMouseLeftButtonDown(object sender, MouseButtonEventArgs e)

--- a/src/GongSolutions.WPF.DragDrop/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.cs
@@ -43,7 +43,7 @@ namespace GongSolutions.Wpf.DragDrop
                         var sorter = TryGetDragPreviewItemsSorter(dragInfo, target);
                         if (sorter != null)
                         {
-                            itemsControl.ItemsSource = sorter.SortDragDropItems(itemsControl.ItemsSource);
+                            itemsControl.ItemsSource = sorter.SortDragPreviewItems(itemsControl.ItemsSource);
                         }
                         
                         itemsControl.ItemTemplate = template;
@@ -322,6 +322,21 @@ namespace GongSolutions.Wpf.DragDrop
             if (handler == null && sender != null)
             {
                 handler = GetDragPreviewItemsSorter(sender);
+            }
+
+            return handler;
+        }
+
+        private static IDropTargetItemsSorter TryGetDropTargetItemsSorter(DropInfo dropInfo, UIElement sender)
+        {
+            IDropTargetItemsSorter handler = null;
+            if (dropInfo != null && dropInfo.VisualTarget != null)
+            {
+                handler = GetDropTargetItemsSorter(dropInfo.VisualTarget);
+            }
+            if (handler == null && sender != null)
+            {
+                handler = GetDropTargetItemsSorter(sender);
             }
 
             return handler;
@@ -751,12 +766,17 @@ namespace GongSolutions.Wpf.DragDrop
             var dropInfo = new DropInfo(sender, e, dragInfo, eventType);
             var dropHandler = TryGetDropHandler(dropInfo, sender as UIElement);
             var dragHandler = TryGetDragHandler(dragInfo, sender as UIElement);
+            var dropTargetSorterHandler = TryGetDropTargetItemsSorter(dropInfo, sender as UIElement);
 
             DragDropPreview = null;
             DragDropEffectPreview = null;
             DropTargetAdorner = null;
 
             dropHandler.DragOver(dropInfo);
+            if (dropTargetSorterHandler != null && dropInfo.Data is IEnumerable enumerable)
+            {
+                dropInfo.Data = dropTargetSorterHandler.SortDropTargetItems(enumerable);
+            }
             dropHandler.Drop(dropInfo);
             dragHandler.Dropped(dropInfo);
 

--- a/src/GongSolutions.WPF.DragDrop/DropInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop/DropInfo.cs
@@ -236,7 +236,7 @@ namespace GongSolutions.Wpf.DragDrop
         }
 
         /// <inheritdoc />
-        public object Data { get; private set; }
+        public object Data { get; internal set; }
 
         /// <inheritdoc />
         public IDragInfo DragInfo { get; private set; }

--- a/src/GongSolutions.WPF.DragDrop/IDragEnumerableSorter.cs
+++ b/src/GongSolutions.WPF.DragDrop/IDragEnumerableSorter.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections;
+
+namespace GongSolutions.Wpf.DragDrop
+{
+    /// <summary>
+    /// Interface for objects that sort an IEnumerable of drag drop items
+    /// </summary>
+    public interface IDragEnumerableSorter
+    {
+        /// <summary>
+        /// Sort the IEnumerable of items
+        /// </summary>
+        /// <param name="items">Enumerable of dragged items to sort</param>
+        /// <returns>The sorted list of dragged items</returns>
+        IEnumerable SortDragDropItems(IEnumerable items);
+    }
+}

--- a/src/GongSolutions.WPF.DragDrop/IDragPreviewItemsSorter.cs
+++ b/src/GongSolutions.WPF.DragDrop/IDragPreviewItemsSorter.cs
@@ -3,7 +3,7 @@
 namespace GongSolutions.Wpf.DragDrop
 {
     /// <summary>
-    /// Interface for objects that sort an IEnumerable of drag drop items
+    /// Interface for objects that sort an IEnumerable of drag preview items
     /// </summary>
     public interface IDragPreviewItemsSorter
     {

--- a/src/GongSolutions.WPF.DragDrop/IDragPreviewItemsSorter.cs
+++ b/src/GongSolutions.WPF.DragDrop/IDragPreviewItemsSorter.cs
@@ -8,10 +8,10 @@ namespace GongSolutions.Wpf.DragDrop
     public interface IDragPreviewItemsSorter
     {
         /// <summary>
-        /// Sort the IEnumerable of items
+        /// Sort the IEnumerable of items that are being shown in a drag preview
         /// </summary>
         /// <param name="items">Enumerable of dragged items to sort</param>
         /// <returns>The sorted list of dragged items</returns>
-        IEnumerable SortDragDropItems(IEnumerable items);
+        IEnumerable SortDragPreviewItems(IEnumerable items);
     }
 }

--- a/src/GongSolutions.WPF.DragDrop/IDragPreviewItemsSorter.cs
+++ b/src/GongSolutions.WPF.DragDrop/IDragPreviewItemsSorter.cs
@@ -5,7 +5,7 @@ namespace GongSolutions.Wpf.DragDrop
     /// <summary>
     /// Interface for objects that sort an IEnumerable of drag drop items
     /// </summary>
-    public interface IDragEnumerableSorter
+    public interface IDragPreviewItemsSorter
     {
         /// <summary>
         /// Sort the IEnumerable of items

--- a/src/GongSolutions.WPF.DragDrop/IDropTargetItemsSorter.cs
+++ b/src/GongSolutions.WPF.DragDrop/IDropTargetItemsSorter.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections;
+
+namespace GongSolutions.Wpf.DragDrop
+{
+    /// <summary>
+    /// Interface for objects that sort an IEnumerable of drag drop items that are 
+    /// going to be dropped on some target
+    /// </summary>
+    public interface IDropTargetItemsSorter
+    {
+        /// <summary>
+        /// Sort the IEnumerable of items that are going to be dropped on a target
+        /// </summary>
+        /// <param name="items">Enumerable of dragged items to sort</param>
+        /// <returns>The sorted list of dragged items</returns>
+        IEnumerable SortDropTargetItems(IEnumerable items);
+    }
+}

--- a/src/Showcase/ViewModels/MainViewModel.cs
+++ b/src/Showcase/ViewModels/MainViewModel.cs
@@ -21,7 +21,7 @@ namespace Showcase.WPF.DragDrop.ViewModels
         public string Name { get; set; }
     }
 
-    public class MainViewModel : ViewModelBase, IDragEnumerableSorter
+    public class MainViewModel : ViewModelBase, IDragPreviewItemsSorter
     {
         private SampleData _data;
         private ICommand _openIssueCommand;

--- a/src/Showcase/ViewModels/MainViewModel.cs
+++ b/src/Showcase/ViewModels/MainViewModel.cs
@@ -21,7 +21,7 @@ namespace Showcase.WPF.DragDrop.ViewModels
         public string Name { get; set; }
     }
 
-    public class MainViewModel : ViewModelBase, IDragPreviewItemsSorter
+    public class MainViewModel : ViewModelBase, IDragPreviewItemsSorter, IDropTargetItemsSorter
     {
         private SampleData _data;
         private ICommand _openIssueCommand;
@@ -143,7 +143,12 @@ namespace Showcase.WPF.DragDrop.ViewModels
             }
         }
 
-        public IEnumerable SortDragDropItems(IEnumerable items)
+        public IEnumerable SortDropTargetItems(IEnumerable items)
+        {
+            return SortDragPreviewItems(items);
+        }
+
+        public IEnumerable SortDragPreviewItems(IEnumerable items)
         {
             var allItems = items.Cast<object>().ToList();
             if (allItems.Count > 0)

--- a/src/Showcase/ViewModels/MainViewModel.cs
+++ b/src/Showcase/ViewModels/MainViewModel.cs
@@ -5,8 +5,11 @@ using Showcase.WPF.DragDrop.Models;
 
 namespace Showcase.WPF.DragDrop.ViewModels
 {
+    using GongSolutions.Wpf.DragDrop;
+    using System.Collections;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
+    using System.Linq;
 
     public class ListMember : List<SubMember>
     {
@@ -18,7 +21,7 @@ namespace Showcase.WPF.DragDrop.ViewModels
         public string Name { get; set; }
     }
 
-    public class MainViewModel : ViewModelBase
+    public class MainViewModel : ViewModelBase, IDragEnumerableSorter
     {
         private SampleData _data;
         private ICommand _openIssueCommand;
@@ -138,6 +141,19 @@ namespace Showcase.WPF.DragDrop.ViewModels
                 _filterCollectionCommand = value;
                 OnPropertyChanged();
             }
+        }
+
+        public IEnumerable SortDragDropItems(IEnumerable items)
+        {
+            var allItems = items.Cast<object>().ToList();
+            if (allItems.Count > 0)
+            {
+                if (allItems[0] is ItemModel)
+                {
+                    return allItems.OrderBy(x => ((ItemModel)x).Index);
+                }
+            }
+            return items;
         }
     }
 }

--- a/src/Showcase/Views/MixedSamples.xaml
+++ b/src/Showcase/Views/MixedSamples.xaml
@@ -48,12 +48,13 @@
                         <DockPanel LastChildFill="True">
                             <TextBlock DockPanel.Dock="Top"
                                        Style="{StaticResource DefaultTextBlockStyle}"
-                                       Text="ListBox" />
+                                       Text="ListBox -- drag preview has sorted items" />
                             <ListBox Height="Auto"
                                      dd:DragDrop.DragAdornerTemplate="{StaticResource DragAdorner}"
                                      dd:DragDrop.IsDragSource="True"
                                      dd:DragDrop.IsDropTarget="True"
                                      dd:DragDrop.UseDefaultEffectDataTemplate="True"
+                                     dd:DragDrop.DragSortHandler="{Binding}"
                                      ItemsSource="{Binding Data.Collection1}" />
                         </DockPanel>
 

--- a/src/Showcase/Views/MixedSamples.xaml
+++ b/src/Showcase/Views/MixedSamples.xaml
@@ -54,7 +54,7 @@
                                      dd:DragDrop.IsDragSource="True"
                                      dd:DragDrop.IsDropTarget="True"
                                      dd:DragDrop.UseDefaultEffectDataTemplate="True"
-                                     dd:DragDrop.DragPreviewSortHandler="{Binding}"
+                                     dd:DragDrop.DragPreviewItemsSorter="{Binding}"
                                      ItemsSource="{Binding Data.Collection1}" />
                         </DockPanel>
 

--- a/src/Showcase/Views/MixedSamples.xaml
+++ b/src/Showcase/Views/MixedSamples.xaml
@@ -67,6 +67,7 @@
                                       dd:DragDrop.IsDragSource="True"
                                       dd:DragDrop.IsDropTarget="True"
                                       dd:DragDrop.UseDefaultEffectDataTemplate="True"
+                                      dd:DragDrop.DropTargetItemsSorter="{Binding}"
                                       ItemsSource="{Binding Data.Collection2}" />
                         </DockPanel>
 

--- a/src/Showcase/Views/MixedSamples.xaml
+++ b/src/Showcase/Views/MixedSamples.xaml
@@ -54,7 +54,7 @@
                                      dd:DragDrop.IsDragSource="True"
                                      dd:DragDrop.IsDropTarget="True"
                                      dd:DragDrop.UseDefaultEffectDataTemplate="True"
-                                     dd:DragDrop.DragSortHandler="{Binding}"
+                                     dd:DragDrop.DragPreviewSortHandler="{Binding}"
                                      ItemsSource="{Binding Data.Collection1}" />
                         </DockPanel>
 

--- a/src/Showcase/Views/MixedSamples.xaml
+++ b/src/Showcase/Views/MixedSamples.xaml
@@ -61,7 +61,7 @@
                         <DockPanel LastChildFill="True">
                             <TextBlock DockPanel.Dock="Top"
                                        Style="{StaticResource DefaultTextBlockStyle}"
-                                       Text="ListView" />
+                                       Text="ListView -- dropped items are added in sorted order" />
                             <ListView Height="Auto"
                                       dd:DragDrop.DragAdornerTemplate="{StaticResource DragAdorner}"
                                       dd:DragDrop.IsDragSource="True"


### PR DESCRIPTION
## What changed?

* Added method for users to sort the items that will be shown in the drag/drop preview. This lets them show a nicer preview to the end user while they are dragging items. In my use case, my users are dragging numbered items, and when they select multiple items out of order, I would like the preview to show the items in numbered order rather than in the order they selected the items.
* Added `IDragPreviewItemsSorter` as an interface for objects that can sort the drag preview items
* Added `DragPreviewItemsSorter` property so you can set this up in your xaml
* Added `IDropTargetItemsSorter` as an interface for objects that want to sort items before they are dropped on a target
* Added `DropTargetItemsSorter` property so you can set up the `IDropTargetItemsSorter` in your xaml as needed
* Added example for the above items in the source code sample under Mixed -> Drag Adorner

### Before (including view model implementation)

![before](https://user-images.githubusercontent.com/5092399/98994889-8a913f80-24fe-11eb-90df-44cbc6c6ee02.gif)

### After

Sorting preview:

![after](https://user-images.githubusercontent.com/5092399/98994894-8c5b0300-24fe-11eb-8b95-45cc80c206ce.gif)

Dropping sorted items on target:

![after2](https://user-images.githubusercontent.com/5092399/99082593-5b2c1280-2592-11eb-892d-47e91154f072.gif)

## Breaking Changes

None. User must implement this manually because we have no idea how to sort their items for them.

## Questions

~~Should `DragPreviewSortHandler` be named `DragPreviewItemsSorterHandler` to match the interface? Or both renamed to something else? Whatever works is good for me.~~
