### PR TITLE
Add .NET 5 compatibility

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <!-- Project properties -->
     <PropertyGroup>
-        <TargetFrameworks>net45;net46;net462;net47;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net45;net46;net462;net47;netcoreapp3.0;netcoreapp3.1;net5-windows</TargetFrameworks>
         <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
         <AutoGenerateBindingRedirects Condition=" $(TargetFramework.StartsWith('net4')) ">true</AutoGenerateBindingRedirects>

--- a/src/Showcase/App.net5-windows.config
+++ b/src/Showcase/App.net5-windows.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<configuration>
+</configuration>


### PR DESCRIPTION
## What changed?

Added .NET 5 output (Windows only). A very quick test using the .NET 5 showcase seems to imply things are still working, but I didn't test everything.

Requires VS 16.8 to use/build.

EDIT: Looks like some dependencies aren't working with .NET 5 yet based on the appveyor build.