### PR TITLE
Update README to show .NET 5 compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
     An easy to use drag'n'drop framework for WPF.
   </p>
   <p>
-    Supporting .NET Framework 4.5+ and .NET Core 3 (3.0 and 3.1)
+    Supporting .NET Framework 4.5+, .NET Core 3 (3.0 and 3.1), and .NET 5 on Windows
   </p>
 
   <a href="https://gitter.im/punker76/gong-wpf-dragdrop">


### PR DESCRIPTION
## What changed?

Just a minor README update to show .NET 5 compatibility (🥳). My suggestion would be to not merge this until 2.4.0 is released so that there is no confusion between what is in the README and what is on NuGet.