### PR TITLE
Better handling of UniformGrid panels

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/Utilities/ItemsControlExtensions.cs
+++ b/src/GongSolutions.WPF.DragDrop/Utilities/ItemsControlExtensions.cs
@@ -268,6 +268,11 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
             if (itemsPresenter != null && VisualTreeHelper.GetChildrenCount(itemsPresenter) > 0)
             {
                 var itemsPanel = VisualTreeHelper.GetChild(itemsPresenter, 0);
+                if (itemsPanel is UniformGrid uniformGrid)
+                {
+                    return uniformGrid.Columns == 1 ? Orientation.Vertical : Orientation.Horizontal;
+                }
+
                 var orientationProperty = itemsPanel.GetType().GetProperty("Orientation", typeof(Orientation));
                 if (orientationProperty != null)
                 {

--- a/src/Showcase/Views/ListBoxSamples.xaml
+++ b/src/Showcase/Views/ListBoxSamples.xaml
@@ -448,6 +448,81 @@
                 </DockPanel>
             </TabItem>
 
+            <TabItem Header="UniformGrid">
+                <DockPanel LastChildFill="True">
+                    <TextBlock
+                        DockPanel.Dock="Top"
+                        Style="{StaticResource SampleHeaderTextBlockStyle}"
+                        Text="UniformGrid" />
+                    <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+                        <StackPanel>
+                            <TextBlock Style="{StaticResource DefaultTextBlockStyle}" Text="Demonstrates insert drop target adorner in ListBox with UniformGrid panel" />
+                            <ListBox
+                                Height="NaN"
+                                dd:DragDrop.DropTargetAdornerBrush="DodgerBlue"
+                                dd:DragDrop.IsDragSource="True"
+                                dd:DragDrop.IsDropTarget="True"
+                                dd:DragDrop.UseDefaultDragAdorner="True">
+                                <ListBox.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <UniformGrid
+                                            HorizontalAlignment="Center"
+                                            IsItemsHost="True"
+                                            Rows="1" />
+                                    </ItemsPanelTemplate>
+                                </ListBox.ItemsPanel>
+                                <ListBoxItem Height="32" Content="Horizontal Item 1" />
+                                <ListBoxItem Content="Horizontal Item 2" />
+                                <ListBoxItem Content="Horizontal Item 3" />
+                            </ListBox>
+                            <ListBox
+                                Height="NaN"
+                                dd:DragDrop.DropTargetAdornerBrush="DodgerBlue"
+                                dd:DragDrop.IsDragSource="True"
+                                dd:DragDrop.IsDropTarget="True"
+                                dd:DragDrop.UseDefaultDragAdorner="True">
+                                <ListBox.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <UniformGrid
+                                            VerticalAlignment="Center"
+                                            Columns="1"
+                                            IsItemsHost="True" />
+                                    </ItemsPanelTemplate>
+                                </ListBox.ItemsPanel>
+                                <ListBoxItem Height="32" Content="Vertical Item 1" />
+                                <ListBoxItem Content="Vertical Item 2" />
+                                <ListBoxItem Content="Vertical Item 3" />
+                            </ListBox>
+                            <ListBox
+                                Height="NaN"
+                                dd:DragDrop.DropTargetAdornerBrush="DodgerBlue"
+                                dd:DragDrop.IsDragSource="True"
+                                dd:DragDrop.IsDropTarget="True"
+                                dd:DragDrop.UseDefaultDragAdorner="True">
+                                <ListBox.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <UniformGrid
+                                            VerticalAlignment="Center"
+                                            Columns="3"
+                                            FirstColumn="1"
+                                            IsItemsHost="True"
+                                            Rows="3" />
+                                    </ItemsPanelTemplate>
+                                </ListBox.ItemsPanel>
+                                <ListBoxItem Height="50" Content="Item 1" />
+                                <ListBoxItem Content="Item 2" />
+                                <ListBoxItem Content="Item 3" />
+                                <ListBoxItem Content="Item 4" />
+                                <ListBoxItem Content="Item 5" />
+                                <ListBoxItem Content="Item 6" />
+                                <ListBoxItem Content="Item 7" />
+                                <ListBoxItem Content="Item 8" />
+                            </ListBox>
+                        </StackPanel>
+                    </ScrollViewer>
+                </DockPanel>
+            </TabItem>
+
         </TabControl>
 
     </Grid>


### PR DESCRIPTION
## What changed?

I added better handling of `UniformGrid` panels. I also added a new sample page in the showcase to test it.

Before this change, when using `UniformGrid` as the items panel on i.e. a `ListBox`, the drop target adorner would default to vertical orientation, since it has no `Orientation` property. However `UniformGrid` has a horizontal flow, except when there is only 1 column.