### PR TITLE
Fix brief deselection of selected item to be selected when changing selected item.

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/Utilities/ItemsControlExtensions.cs
+++ b/src/GongSolutions.WPF.DragDrop/Utilities/ItemsControlExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
@@ -310,17 +310,33 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
         {
             if (itemsControl is MultiSelector multiSelector)
             {
-                multiSelector.SetCurrentValue(Selector.SelectedItemProperty, null);
+                object[] itemsToDeselect = multiSelector.SelectedItems.Cast<object>().Where(si => si != item).ToArray();
+
+                for (int i = 0; i < itemsToDeselect.Length; ++i)
+                {
+                    multiSelector.SelectedItems.Remove(itemsToDeselect[i]);
+                }
+
                 multiSelector.SetCurrentValue(Selector.SelectedItemProperty, item);
             }
             else if (itemsControl is ListBox listBox)
             {
                 var selectionMode = listBox.SelectionMode;
+
+                if (selectionMode != SelectionMode.Single)
+                {
+                    object[] itemsToDeselect = listBox.SelectedItems.Cast<object>().Where(si => si != item).ToArray();
+
+                    for (int i = 0; i < itemsToDeselect.Length; ++i)
+                    {
+                        listBox.SelectedItems.Remove(itemsToDeselect[i]);
+                    }
+                }
+
                 try
                 {
                     // change SelectionMode for UpdateAnchorAndActionItem
                     listBox.SetCurrentValue(ListBox.SelectionModeProperty, SelectionMode.Single);
-                    listBox.SetCurrentValue(Selector.SelectedItemProperty, null);
                     listBox.SetCurrentValue(Selector.SelectedItemProperty, item);
                 }
                 finally


### PR DESCRIPTION
In the `SetSelectedItem()` method of `ItemsControlExtensions`, it sets the `SelectedItem` to `null` before setting it to the value passed in.  For an existing multi-selection, the value being selected could already be within that existing selection, meaning that the item we wish to select is being deselected and then selected again.

This behaviour can make `SelectionChanged` event handling somewhat problematic further down the line (an application I'm working manages what selection behaviour in the `SelectionChanged` events for nested `DataGrid instances, and the deselection of all rows, followed by the selection of the correct one for the parent `DataGrid` had implications for the child `DataGrid` instance's selected rows.  This relates to the other pull request I've raised, https://github.com/punker76/gong-wpf-dragdrop/pull/378).

## What changed?

* Updated SetSelectedItem() method in ItemsControlExtensions to not deselect the item we're selecting before before selecting it again.

The original change  (https://github.com/punker76/gong-wpf-dragdrop/commit/df10543240faa021f1d7f3fa8182c27eb6e4405f) to set the `SelectedItem` to `null` first before setting it to the new value was made to resolve issue #21.  The change made in this pull request does not regress that issue.