### PR TITLE
Added bounds calculation workaround

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.cs
@@ -57,7 +57,7 @@ namespace GongSolutions.Wpf.DragDrop
 
                         if (useVisualSourceItemSizeForDragAdorner)
                         {
-                            var bounds = VisualTreeHelper.GetDescendantBounds(dragInfo.VisualSourceItem);
+                            var bounds = VisualTreeExtensions.GetVisibleDescendantBounds(dragInfo.VisualSourceItem);
                             itemsControl.SetValue(FrameworkElement.MinWidthProperty, bounds.Width);
                         }
 
@@ -78,7 +78,7 @@ namespace GongSolutions.Wpf.DragDrop
 
                     if (useVisualSourceItemSizeForDragAdorner)
                     {
-                        var bounds = VisualTreeHelper.GetDescendantBounds(dragInfo.VisualSourceItem);
+                        var bounds = VisualTreeExtensions.GetVisibleDescendantBounds(dragInfo.VisualSourceItem);
                         contentPresenter.SetValue(FrameworkElement.MinWidthProperty, bounds.Width);
                         contentPresenter.SetValue(FrameworkElement.MinHeightProperty, bounds.Height);
                     }

--- a/src/GongSolutions.WPF.DragDrop/DropTargetHighlightAdorner.cs
+++ b/src/GongSolutions.WPF.DragDrop/DropTargetHighlightAdorner.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using GongSolutions.Wpf.DragDrop.Utilities;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 
@@ -28,7 +29,7 @@ namespace GongSolutions.Wpf.DragDrop
                 var tvItem = visualTargetItem as TreeViewItem;
                 if (tvItem != null && VisualTreeHelper.GetChildrenCount(tvItem) > 0)
                 {
-                    var descendant = VisualTreeHelper.GetDescendantBounds(tvItem);
+                    var descendant = VisualTreeExtensions.GetVisibleDescendantBounds(tvItem);
                     var translatePoint = tvItem.TranslatePoint(new Point(), this.AdornedElement);
                     var itemRect = new Rect(translatePoint, tvItem.RenderSize);
                     descendant.Union(itemRect);
@@ -37,7 +38,7 @@ namespace GongSolutions.Wpf.DragDrop
                 }
                 if (rect.IsEmpty)
                 {
-                    rect = new Rect(visualTargetItem.TranslatePoint(new Point(), this.AdornedElement), VisualTreeHelper.GetDescendantBounds(visualTargetItem).Size);
+                    rect = new Rect(visualTargetItem.TranslatePoint(new Point(), this.AdornedElement), VisualTreeExtensions.GetVisibleDescendantBounds(visualTargetItem).Size);
                 }
                 drawingContext.DrawRoundedRectangle(null, this.Pen, rect, 2, 2);
             }

--- a/src/GongSolutions.WPF.DragDrop/Utilities/DragDropExtensions.cs
+++ b/src/GongSolutions.WPF.DragDrop/Utilities/DragDropExtensions.cs
@@ -52,7 +52,7 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
 
             var relativeItemPosition = element.TranslatePoint(new Point(0, 0), relativeToElement);
             var relativeDropPosition = new Point(dropPosition.X - relativeItemPosition.X, dropPosition.Y - relativeItemPosition.Y);
-            return VisualTreeHelper.GetDescendantBounds(element).Contains(relativeDropPosition);
+            return VisualTreeExtensions.GetVisibleDescendantBounds(element).Contains(relativeDropPosition);
         }
 
         /// <summary>
@@ -91,18 +91,19 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
             }
 
             var bounds = VisualTreeHelper.GetDescendantBounds(target);
+            var cropBounds = VisualTreeExtensions.GetVisibleDescendantBounds(target);
 
 #if NET461 || NET46 || NET452 || NET451 || NET45
             var dpiX = DpiHelper.DpiX;
             var dpiY = DpiHelper.DpiY;
 
-            var dpiBounds = DpiHelper.LogicalRectToDevice(bounds);
+            var dpiBounds = DpiHelper.LogicalRectToDevice(cropBounds);
 #else
             var dpiScale = VisualTreeHelper.GetDpi(target);
             var dpiX = dpiScale.PixelsPerInchX;
             var dpiY = dpiScale.PixelsPerInchY;
 
-            var dpiBounds = DpiHelper.LogicalRectToDevice(bounds, dpiScale.DpiScaleX, dpiScale.DpiScaleY);
+            var dpiBounds = DpiHelper.LogicalRectToDevice(cropBounds, dpiScale.DpiScaleX, dpiScale.DpiScaleY);
 #endif
 
             var pixelWidth = (int)Math.Ceiling(dpiBounds.Width);
@@ -118,6 +119,10 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
             using (var ctx = dv.RenderOpen())
             {
                 var vb = new VisualBrush(target);
+
+                vb.ViewportUnits = BrushMappingMode.Absolute;
+                vb.Viewport = bounds;
+
                 if (flowDirection == FlowDirection.RightToLeft)
                 {
                     var transformGroup = new TransformGroup();

--- a/src/GongSolutions.WPF.DragDrop/Utilities/Microsoft WPF License.txt
+++ b/src/GongSolutions.WPF.DragDrop/Utilities/Microsoft WPF License.txt
@@ -1,0 +1,25 @@
+﻿This license applies to modified Microsoft WPF code used in GongSolutions.WPF.DragDrop/Utilities/VisualTreeDescendantBoundsHelper.cs and originally sourced from https://github.com/dotnet/wpf/blob/83b9af142acd341d4bf470450e8b5c3ec3723d76/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Visual.cs
+
+The MIT License (MIT)
+
+Copyright (c) .NET Foundation and Contributors
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/GongSolutions.WPF.DragDrop/Utilities/VisualTreeDescendantBoundsHelper.cs
+++ b/src/GongSolutions.WPF.DragDrop/Utilities/VisualTreeDescendantBoundsHelper.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Effects;
+
+namespace GongSolutions.Wpf.DragDrop.Utilities
+{
+    public static class VisualTreeDescendantBoundsHelper
+    {
+        private static Assembly PresentationCoreAssembly { get; } = typeof(ContentElement).Assembly;
+        private static Assembly WindowsBaseAssembly { get; } = typeof(System.ComponentModel.GroupDescription).Assembly;
+
+        private static FieldInfo OffsetFieldInfo { get; } = typeof(Visual).GetField("_offset", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        private static Type UncommonFieldType { get; } = WindowsBaseAssembly.GetType("System.Windows.UncommonField`1");
+        private static Func<Type, MethodInfo> GetValueMethodInfo { get; } = t => UncommonFieldType.MakeGenericType(t).GetMethod("GetValue", BindingFlags.Instance | BindingFlags.Public);
+
+        private static Type BitmapEffectStateType { get; } = PresentationCoreAssembly.GetType("System.Windows.Media.Effects.BitmapEffectState");
+        private static Type VisualFlagsType { get; } = PresentationCoreAssembly.GetType("System.Windows.Media.VisualFlags");
+
+        // UncommonFields
+        private static FieldInfo ScrollableAreaClipFieldFieldInfo { get; } = typeof(Visual).GetField("ScrollableAreaClipField", BindingFlags.Static | BindingFlags.NonPublic);
+        private static FieldInfo EffectFieldFieldInfo { get; } = typeof(Visual).GetField("EffectField", BindingFlags.Static | BindingFlags.NonPublic);
+        private static FieldInfo TransformFieldFieldInfo { get; } = typeof(Visual).GetField("TransformField", BindingFlags.Static | BindingFlags.NonPublic);
+        private static FieldInfo BitmapEffectStateFieldFieldInfo { get; } = typeof(Visual).GetField("BitmapEffectStateField", BindingFlags.Static | BindingFlags.NonPublic);
+        private static FieldInfo ClipFieldFieldInfo { get; } = typeof(Visual).GetField("ClipField", BindingFlags.Static | BindingFlags.NonPublic);
+        private static MethodInfo IsEmptyRenderBoundsMethodInfo { get; } = typeof(Visual).GetMethod("IsEmptyRenderBounds", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static MethodInfo CheckFlagsAndMethodInfo { get; } = typeof(Visual).GetMethod("CheckFlagsAnd", BindingFlags.Instance | BindingFlags.NonPublic, null, new Type[] { VisualFlagsType }, null);
+
+        private static PropertyInfo EffectMappingPropertyInfo { get; } = typeof(Effect).GetProperty("EffectMapping", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static MethodInfo UnitToWorldMethodInfo { get; } = typeof(Effect).GetMethod("UnitToWorld", BindingFlags.Static | BindingFlags.NonPublic, null, new Type[] { typeof(Rect), typeof(Rect) }, null);
+
+        private static PropertyInfo IsIdentityPropertyInfo { get; } = typeof(Transform).GetProperty("IsIdentity", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        // Microsoft utility methods
+        private static MethodInfo TransformRectMethodInfo { get; } = WindowsBaseAssembly.GetType("MS.Internal.MatrixUtil").GetMethod("TransformRect", BindingFlags.Static | BindingFlags.NonPublic);
+        private static MethodInfo RectHasNaNMethodInfo { get; } = WindowsBaseAssembly.GetType("MS.Internal.DoubleUtil").GetMethod("RectHasNaN", BindingFlags.Static | BindingFlags.Public);
+
+        public static Rect GetVisibleDescendantBounds(Visual visual)
+        {
+            Rect boundingBoxSubGraph = CalculateSubgraphBoundsInnerSpace(visual, false);
+
+            if ((bool)RectHasNaNMethodInfo.Invoke(null, new object[] { boundingBoxSubGraph }))
+            {
+                boundingBoxSubGraph.X = Double.NegativeInfinity;
+                boundingBoxSubGraph.Y = Double.NegativeInfinity;
+                boundingBoxSubGraph.Width = Double.PositiveInfinity;
+                boundingBoxSubGraph.Height = Double.PositiveInfinity;
+            }
+            return boundingBoxSubGraph;
+        }
+
+        private static Rect CalculateSubgraphBoundsInnerSpace(Visual visual, bool renderBounds)
+        {
+            Rect boundingBoxSubGraph = Rect.Empty;
+
+            int count = VisualTreeHelper.GetChildrenCount(visual);
+
+            for (int i = 0; i < count; i++)
+            {
+                Visual child = VisualTreeHelper.GetChild(visual, i) as Visual;
+
+                if (child != null && ((bool)CheckFlagsAndMethodInfo.Invoke(child, new object[] { Enum.Parse(VisualFlagsType, "VisibilityCache_Visible") }) || (bool)CheckFlagsAndMethodInfo.Invoke(child, new object[] { Enum.Parse(VisualFlagsType, "VisibilityCache_TakesSpace") })))
+                {
+                    Rect boundingBoxSubGraphChild = CalculateSubgraphBoundsOuterSpace(child, renderBounds);
+                    boundingBoxSubGraph.Union(boundingBoxSubGraphChild);
+                }
+            }
+
+            Rect contentBounds = VisualTreeHelper.GetContentBounds(visual);
+
+            if (renderBounds && (bool)IsEmptyRenderBoundsMethodInfo.Invoke(visual, new object[] { contentBounds }))
+            {
+                contentBounds = Rect.Empty;
+            }
+
+            boundingBoxSubGraph.Union(contentBounds);
+
+            return boundingBoxSubGraph;
+        }
+
+        private static Rect CalculateSubgraphBoundsOuterSpace(Visual visual, bool renderBounds)
+        {
+            Rect boundingBoxSubGraph = CalculateSubgraphBoundsInnerSpace(visual, renderBounds);
+
+            if ((bool)CheckFlagsAndMethodInfo.Invoke(visual, new object[] { Enum.Parse(VisualFlagsType, "NodeHasEffect") }))
+            {
+                Effect effect = (Effect)GetValueMethodInfo(typeof(Effect)).Invoke(EffectFieldFieldInfo.GetValue(visual), new object[] { visual });
+
+                if (effect != null)
+                {
+                    Rect unitBounds = new Rect(0, 0, 1, 1);
+                    Rect unitTransformedBounds = (EffectMappingPropertyInfo.GetValue(effect) as GeneralTransform).TransformBounds(unitBounds);
+                    Rect effectBounds = (Rect)UnitToWorldMethodInfo.Invoke(null, new object[] { unitTransformedBounds, boundingBoxSubGraph });
+
+                    boundingBoxSubGraph.Union(effectBounds);
+                }
+                else
+                {
+                    Debug.Assert(GetValueMethodInfo(BitmapEffectStateType).Invoke(BitmapEffectStateFieldFieldInfo.GetValue(visual), new object[] { visual }) != null);
+                }
+            }
+
+            Geometry clip = (Geometry)GetValueMethodInfo(typeof(Geometry)).Invoke(ClipFieldFieldInfo.GetValue(visual), new object[] { visual });
+
+            if (clip != null)
+            {
+                boundingBoxSubGraph.Intersect(clip.Bounds);
+            }
+
+            Transform transform = (Transform)GetValueMethodInfo(typeof(Transform)).Invoke(TransformFieldFieldInfo.GetValue(visual), new object[] { visual });
+
+            if ((transform != null) && (!(bool)IsIdentityPropertyInfo.GetValue(transform)))
+            {
+                Matrix matrix = transform.Value;
+                TransformRectMethodInfo.Invoke(null, new object[] { boundingBoxSubGraph, matrix });
+            }
+
+            if (!boundingBoxSubGraph.IsEmpty)
+            {
+                var _offset = (Vector)OffsetFieldInfo.GetValue(visual);
+                boundingBoxSubGraph.X += _offset.X;
+                boundingBoxSubGraph.Y += _offset.Y;
+            }
+
+            Rect? scrollClip = (Rect?)GetValueMethodInfo(typeof(Rect?)).Invoke(ScrollableAreaClipFieldFieldInfo.GetValue(visual), new object[] { visual });
+
+            if (scrollClip.HasValue)
+            {
+                boundingBoxSubGraph.Intersect(scrollClip.Value);
+            }
+
+            if ((bool)RectHasNaNMethodInfo.Invoke(null, new object[] { boundingBoxSubGraph }))
+            {
+                boundingBoxSubGraph.X = Double.NegativeInfinity;
+                boundingBoxSubGraph.Y = Double.NegativeInfinity;
+                boundingBoxSubGraph.Width = Double.PositiveInfinity;
+                boundingBoxSubGraph.Height = Double.PositiveInfinity;
+            }
+
+            return boundingBoxSubGraph;
+        }
+    }
+}

--- a/src/GongSolutions.WPF.DragDrop/Utilities/VisualTreeExtensions.cs
+++ b/src/GongSolutions.WPF.DragDrop/Utilities/VisualTreeExtensions.cs
@@ -165,5 +165,10 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
 
             yield break;
         }
+
+        public static Rect GetVisibleDescendantBounds(Visual visual)
+        {
+            return VisualTreeDescendantBoundsHelper.GetVisibleDescendantBounds(visual);
+        }
     }
 }


### PR DESCRIPTION
`VisualTreeHelper.GetDescendantBounds()` does not account for collapsed descendants, resulting in various rendering issues when dealing with drag and drop functionality for elements that can have collapsed components (ie `TreeViewItem` instances and `DataGridRow` instances with row details).  Further details can be found [here](https://github.com/dotnet/wpf/issues/5057#issuecomment-897146992).

## What changed?
* Added VisualTreeDescendantBoundsHelper to work around bug/feature of VisualTreeHelper.GetDescendantBounds() including collapsed Visuals in its bounds calculations.


_Closed issues._

Closes #346
