### PR TITLE
Fix item selection/deselection in ItemsControl (inside TabControl) when multiple/extended selection is enabled

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.cs
@@ -444,13 +444,6 @@ namespace GongSolutions.Wpf.DragDrop
 
         private static void DragSourceUp(object sender, Point elementPosition)
         {
-            if (sender is TabControl && !HitTestUtilities.HitTest4Type<TabPanel>(sender, elementPosition))
-            {
-                _dragInfo = null;
-                _clickSupressItem = null;
-                return;
-            }
-
             var dragInfo = _dragInfo;
 
             // If we prevented the control's default selection handling in DragSource_PreviewMouseLeftButtonDown

--- a/src/GongSolutions.WPF.DragDrop/DropInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop/DropInfo.cs
@@ -176,6 +176,7 @@ namespace GongSolutions.Wpf.DragDrop
                                 this.TargetCollection = tvItem.ItemsSource ?? tvItem.Items;
                                 this.InsertIndex = this.TargetCollection != null ? this.TargetCollection.OfType<object>().Count() : 0;
                             }
+
                             this.InsertPosition |= RelativeInsertPosition.TargetItemCenter;
                         }
                         //System.Diagnostics.Debug.WriteLine("==> DropInfo: pos={0}, idx={1}, Y={2}, Item={3}", this.InsertPosition, this.InsertIndex, currentYPos, item);
@@ -217,6 +218,7 @@ namespace GongSolutions.Wpf.DragDrop
                                 this.TargetCollection = tvItem.ItemsSource ?? tvItem.Items;
                                 this.InsertIndex = this.TargetCollection != null ? this.TargetCollection.OfType<object>().Count() : 0;
                             }
+
                             this.InsertPosition |= RelativeInsertPosition.TargetItemCenter;
                         }
                         //System.Diagnostics.Debug.WriteLine("==> DropInfo: pos={0}, idx={1}, X={2}, Item={3}", this.InsertPosition, this.InsertIndex, currentXPos, item);
@@ -282,6 +284,7 @@ namespace GongSolutions.Wpf.DragDrop
                         }
                     }
                 }
+
                 return insertIndex;
             }
         }
@@ -338,24 +341,23 @@ namespace GongSolutions.Wpf.DragDrop
             get
             {
                 // Check if DragInfo stuff exists
-                if (this.DragInfo == null || this.DragInfo.VisualSource == null)
+                if (this.DragInfo?.VisualSource is null)
                 {
                     return true;
                 }
+
                 // A target should be exists
-                if (this.VisualTarget == null)
+                if (this.VisualTarget is null)
                 {
                     return true;
                 }
 
                 // Source element has a drag context constraint, we need to check the target property matches.
-                var sourceContext = this.DragInfo.VisualSource.GetValue(DragDrop.DragDropContextProperty) as string;
-                if (String.IsNullOrEmpty(sourceContext))
-                {
-                    return true;
-                }
-                var targetContext = this.VisualTarget.GetValue(DragDrop.DragDropContextProperty) as string;
-                return string.Equals(sourceContext, targetContext);
+                var sourceContext = DragDrop.GetDragDropContext(this.DragInfo.VisualSource);
+                var targetContext = DragDrop.GetDragDropContext(this.VisualTarget);
+
+                return string.Equals(sourceContext, targetContext)
+                       || string.IsNullOrEmpty(targetContext);
             }
         }
 

--- a/src/GongSolutions.WPF.DragDrop/Utilities/VisualTreeExtensions.cs
+++ b/src/GongSolutions.WPF.DragDrop/Utilities/VisualTreeExtensions.cs
@@ -148,10 +148,22 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
         public static T GetVisualDescendent<T>(this DependencyObject d)
             where T : DependencyObject
         {
-            return d.GetVisualDescendents<T>().FirstOrDefault();
+            return d.GetVisualDescendents<T>(null).FirstOrDefault();
+        }
+
+        public static T GetVisualDescendent<T>(this DependencyObject d, string childName)
+            where T : DependencyObject
+        {
+            return d.GetVisualDescendents<T>(childName).FirstOrDefault();
         }
 
         public static IEnumerable<T> GetVisualDescendents<T>(this DependencyObject d)
+            where T : DependencyObject
+        {
+            return d.GetVisualDescendents<T>(null);
+        }
+
+        public static IEnumerable<T> GetVisualDescendents<T>(this DependencyObject d, string childName)
             where T : DependencyObject
         {
             var childCount = VisualTreeHelper.GetChildrenCount(d);
@@ -160,12 +172,16 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
             {
                 var child = VisualTreeHelper.GetChild(d, n);
 
-                if (child is T)
+                if (child is T descendent)
                 {
-                    yield return (T)child;
+                    if (string.IsNullOrEmpty(childName)
+                        || descendent is IFrameworkInputElement frameworkInputElement && frameworkInputElement.Name == childName)
+                    {
+                        yield return descendent;
+                    }
                 }
 
-                foreach (var match in GetVisualDescendents<T>(child))
+                foreach (var match in GetVisualDescendents<T>(child, childName))
                 {
                     yield return match;
                 }

--- a/src/Showcase/Views/Issues.xaml
+++ b/src/Showcase/Views/Issues.xaml
@@ -1050,6 +1050,88 @@
                 </DockPanel>
             </TabItem>
 
+            <TabItem Header="#336">
+                <DockPanel LastChildFill="True">
+                    <Grid DockPanel.Dock="Top">
+                        <TextBlock Style="{StaticResource SampleHeaderTextBlockStyle}" Text="Item selection in ItemsControl is not handled" />
+                        <Button CommandParameter="336"
+                                Style="{StaticResource GitHubIssueButtonStyle}"
+                                ToolTip="Open #336 on Github" />
+                    </Grid>
+                    <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+                        <StackPanel>
+                            <TextBlock Style="{StaticResource DefaultTextBlockStyle}" Text="Item selection/deselection in ItemsControl should be handled when multiple/extended selection is enabled inside a TabControl." />
+                            
+                            <TabControl dd:DragDrop.IsDragSource="True"
+                                        dd:DragDrop.IsDropTarget="True"
+                                        dd:DragDrop.DragDropContext="TabControl">
+                                <TabItem Header="ListBox 1 Extended">
+                                    <ListBox dd:DragDrop.IsDragSource="True"
+                                             dd:DragDrop.IsDropTarget="True"
+                                             dd:DragDrop.UseDefaultDragAdorner="True"
+                                             dd:DragDrop.UseDefaultEffectDataTemplate="True"
+                                             Margin="5"
+                                             SelectionMode="Extended">
+                                        <ListBoxItem Content="Item 1" />
+                                        <ListBoxItem Content="Item 2" />
+                                        <ListBoxItem Content="Item 3" />
+                                        <ListBoxItem Content="Item 4" />
+                                        <ListBoxItem Content="Item 5" />
+                                    </ListBox>
+                                </TabItem>
+                                <TabItem Header="ListBox 2 Multiple">
+                                    <ListBox dd:DragDrop.IsDragSource="True"
+                                             dd:DragDrop.IsDropTarget="True"
+                                             dd:DragDrop.DragDropContext="ListBox"
+                                             dd:DragDrop.UseDefaultDragAdorner="True"
+                                             dd:DragDrop.UseDefaultEffectDataTemplate="True"
+                                             Margin="5"
+                                             SelectionMode="Multiple">
+                                        <ListBoxItem Content="Item 11" />
+                                        <ListBoxItem Content="Item 12" />
+                                        <ListBoxItem Content="Item 13" />
+                                        <ListBoxItem Content="Item 14" />
+                                        <ListBoxItem Content="Item 15" />
+                                    </ListBox>
+                                </TabItem>
+
+                                <TabItem Header="ListView 1 Extended">
+                                    <ListView dd:DragDrop.IsDragSource="True"
+                                              dd:DragDrop.IsDropTarget="True"
+                                              dd:DragDrop.DragDropContext="ListView"
+                                              dd:DragDrop.UseDefaultDragAdorner="True"
+                                              dd:DragDrop.UseDefaultEffectDataTemplate="True"
+                                              Margin="5"
+                                              SelectionMode="Extended">
+                                        <ListViewItem Content="Item 1" />
+                                        <ListViewItem Content="Item 2" />
+                                        <ListViewItem Content="Item 3" />
+                                        <ListViewItem Content="Item 4" />
+                                        <ListViewItem Content="Item 5" />
+                                    </ListView>
+                                </TabItem>
+                                <TabItem Header="ListView 2 Multiple">
+                                    <ListView dd:DragDrop.IsDragSource="True"
+                                              dd:DragDrop.IsDropTarget="True"
+                                              dd:DragDrop.DragDropContext="ListView"
+                                              dd:DragDrop.UseDefaultDragAdorner="True"
+                                              dd:DragDrop.UseDefaultEffectDataTemplate="True"
+                                              Margin="5"
+                                              SelectionMode="Multiple">
+                                        <ListViewItem Content="Item 11" />
+                                        <ListViewItem Content="Item 12" />
+                                        <ListViewItem Content="Item 13" />
+                                        <ListViewItem Content="Item 14" />
+                                        <ListViewItem Content="Item 15" />
+                                    </ListView>
+                                </TabItem>
+                            </TabControl>
+
+                        </StackPanel>
+                    </ScrollViewer>
+                </DockPanel>
+            </TabItem>
+
             <TabItem Header="#296">
                 <DockPanel LastChildFill="True">
                     <Grid DockPanel.Dock="Top">


### PR DESCRIPTION
## What changed?

- Fix item selection/deselection in ItemsControl (inside TabControl) when multiple/extended selection is enabled
- Improve GetVisualDescendent and GetVisualDescendents method with searching for a child name
- Fix IsSameDragDropContextAsSource calculation

_Closed issues._

Closes #336 
