### PR TITLE
Fix for drag preview doesn't show up if the source is not a target

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/DragDropPreview.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDropPreview.cs
@@ -1,7 +1,12 @@
-using System;
+﻿using System;
+using System.Collections;
+using System.Linq;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
+using System.Windows.Data;
 using System.Windows.Interop;
+using System.Windows.Media;
 using GongSolutions.Wpf.DragDrop.Utilities;
 
 namespace GongSolutions.Wpf.DragDrop
@@ -26,25 +31,89 @@ namespace GongSolutions.Wpf.DragDrop
             this.AnchorPoint = anchorPoint;
         }
 
+        public DragDropPreview(UIElement rootElement, IDragInfo dragInfo, UIElement visualTarget, UIElement sender)
+        {
+            this.PlacementTarget = rootElement;
+            this.Placement = PlacementMode.Relative;
+            this.AllowsTransparency = true;
+            this.Focusable = false;
+            this.PopupAnimation = PopupAnimation.Fade;
+            this.StaysOpen = true;
+            this.HorizontalOffset = -9999;
+            this.VerticalOffset = -9999;
+            this.IsHitTestVisible = false;
+            this.AllowDrop = false;
+            this.HorizontalAlignment = HorizontalAlignment.Left;
+            this.VerticalAlignment = VerticalAlignment.Top;
+
+            this.DragInfo = dragInfo;
+            this.Child = this.CreatePreviewPresenter(dragInfo, visualTarget, sender);
+            this.Translation = DragDrop.GetDragAdornerTranslation(dragInfo.VisualSource);
+            this.AnchorPoint = DragDrop.GetDragMouseAnchorPoint(dragInfo.VisualSource);
+        }
+
+        private IDragInfo DragInfo { get; }
+
+        private Rect VisualSourceItemBounds { get; set; } = Rect.Empty;
+
         public Point Translation { get; }
 
         public Point AnchorPoint { get; }
 
-        internal void Move(Point point)
+        public bool UseDefaultDragAdorner { get; private set; }
+
+        public static readonly DependencyProperty ItemTemplateProperty
+            = DependencyProperty.Register(nameof(ItemTemplate),
+                                          typeof(DataTemplate),
+                                          typeof(DragDropPreview),
+                                          new FrameworkPropertyMetadata((DataTemplate)null));
+
+        public DataTemplate ItemTemplate
+        {
+            get => (DataTemplate)this.GetValue(ItemTemplateProperty);
+            set => this.SetValue(ItemTemplateProperty, value);
+        }
+
+        public static readonly DependencyProperty ItemTemplateSelectorProperty
+            = DependencyProperty.Register(nameof(ItemTemplateSelector),
+                                          typeof(DataTemplateSelector),
+                                          typeof(DragDropPreview),
+                                          new FrameworkPropertyMetadata((DataTemplateSelector)null));
+
+        public DataTemplateSelector ItemTemplateSelector
+        {
+            get => (DataTemplateSelector)this.GetValue(ItemTemplateSelectorProperty);
+            set => this.SetValue(ItemTemplateSelectorProperty, value);
+        }
+
+        public void Move(Point point)
         {
             var translation = this.Translation;
             var translationX = point.X + translation.X;
             var translationY = point.Y + translation.Y;
 
-            var renderSize = this.Child.RenderSize;
-
-            if (renderSize.Width > 0 && renderSize.Height > 0)
+            if (this.Child is not null)
             {
-                var offsetX = renderSize.Width * -this.AnchorPoint.X;
-                var offsetY = renderSize.Height * -this.AnchorPoint.Y;
+                var renderSize = this.Child.RenderSize;
 
-                translationX += offsetX;
-                translationY += offsetY;
+                var renderSizeWidth = renderSize.Width;
+                var renderSizeHeight = renderSize.Height;
+
+                // Only set if the template contains a Canvas.
+                if (!this.VisualSourceItemBounds.IsEmpty)
+                {
+                    renderSizeWidth = Math.Min(renderSizeWidth, this.VisualSourceItemBounds.Width);
+                    renderSizeHeight = Math.Min(renderSizeHeight, this.VisualSourceItemBounds.Height);
+                }
+
+                if (renderSizeWidth > 0 && renderSizeHeight > 0)
+                {
+                    var offsetX = renderSizeWidth * -this.AnchorPoint.X;
+                    var offsetY = renderSizeHeight * -this.AnchorPoint.Y;
+
+                    translationX += offsetX;
+                    translationY += offsetY;
+                }
             }
 
             this.SetCurrentValue(HorizontalOffsetProperty, translationX);
@@ -65,6 +134,157 @@ namespace GongSolutions.Wpf.DragDrop
                 wsex |= WindowStyleHelper.WS_EX.TRANSPARENT;
 
                 WindowStyleHelper.SetWindowStyleEx(windowHandle, wsex);
+            }
+        }
+
+        public void UpdatePreviewPresenter(IDragInfo dragInfo, UIElement visualTarget, UIElement sender)
+        {
+            if (this.UseDefaultDragAdorner)
+            {
+                return;
+            }
+
+            var visualSource = dragInfo.VisualSource;
+
+            DataTemplate template = DragDrop.TryGetDropAdornerTemplate(visualTarget, sender) ?? DragDrop.TryGetDragAdornerTemplate(visualSource, sender);
+            DataTemplateSelector templateSelector = DragDrop.TryGetDropAdornerTemplateSelector(visualTarget, sender) ?? DragDrop.TryGetDragAdornerTemplateSelector(visualSource, sender);
+
+            if (template is not null)
+            {
+                templateSelector = null;
+            }
+
+            this.SetCurrentValue(ItemTemplateProperty, template);
+            this.SetCurrentValue(ItemTemplateSelectorProperty, templateSelector);
+        }
+
+        public UIElement CreatePreviewPresenter(IDragInfo dragInfo, UIElement visualTarget, UIElement sender)
+        {
+            var visualSource = dragInfo.VisualSource;
+
+            DataTemplate template = DragDrop.TryGetDropAdornerTemplate(visualTarget, sender) ?? DragDrop.TryGetDragAdornerTemplate(visualSource, sender);
+            DataTemplateSelector templateSelector = DragDrop.TryGetDropAdornerTemplateSelector(visualTarget, sender) ?? DragDrop.TryGetDragAdornerTemplateSelector(visualSource, sender);
+
+            var useDefaultDragAdorner = template is null && templateSelector is null && DragDrop.GetUseDefaultDragAdorner(visualSource);
+            var useVisualSourceItemSizeForDragAdorner = dragInfo.VisualSourceItem != null && DragDrop.GetUseVisualSourceItemSizeForDragAdorner(visualSource);
+
+            if (useDefaultDragAdorner)
+            {
+                template = dragInfo.VisualSourceItem.GetCaptureScreenDataTemplate(dragInfo.VisualSourceFlowDirection);
+                useDefaultDragAdorner = template is not null;
+            }
+
+            if (template is not null)
+            {
+                templateSelector = null;
+            }
+
+            this.SetCurrentValue(ItemTemplateProperty, template);
+            this.SetCurrentValue(ItemTemplateSelectorProperty, templateSelector);
+
+            this.UseDefaultDragAdorner = useDefaultDragAdorner;
+
+            UIElement adornment = null;
+
+            if (template != null || templateSelector != null)
+            {
+                if (dragInfo.Data is IEnumerable items && !(items is string))
+                {
+                    var itemsCount = items.Cast<object>().Count();
+                    var maxItemsCount = DragDrop.TryGetDragPreviewMaxItemsCount(dragInfo, sender);
+                    if (!useDefaultDragAdorner && itemsCount <= maxItemsCount)
+                    {
+                        // sort items if necessary before creating the preview
+                        var sorter = DragDrop.TryGetDragPreviewItemsSorter(dragInfo, sender);
+
+                        var itemsControl = new ItemsControl
+                                           {
+                                               ItemsSource = sorter?.SortDragPreviewItems(items) ?? items,
+                                               Tag = dragInfo
+                                           };
+
+                        itemsControl.SetBinding(ItemsControl.ItemTemplateProperty, new Binding(nameof(this.ItemTemplate)) { Source = this });
+                        itemsControl.SetBinding(ItemsControl.ItemTemplateSelectorProperty, new Binding(nameof(this.ItemTemplateSelector)) { Source = this });
+
+                        if (useVisualSourceItemSizeForDragAdorner)
+                        {
+                            var bounds = VisualTreeExtensions.GetVisibleDescendantBounds(dragInfo.VisualSourceItem);
+                            itemsControl.SetCurrentValue(MinWidthProperty, bounds.Width);
+                        }
+
+                        // The ItemsControl doesn't display unless we create a grid to contain it.
+                        var grid = new Grid();
+                        grid.Children.Add(itemsControl);
+                        adornment = grid;
+                    }
+                }
+                else
+                {
+                    var contentPresenter = new ContentPresenter
+                                           {
+                                               Content = dragInfo.Data,
+                                               Tag = dragInfo
+                                           };
+
+                    contentPresenter.SetBinding(ContentPresenter.ContentTemplateProperty, new Binding(nameof(this.ItemTemplate)) { Source = this });
+                    contentPresenter.SetBinding(ContentPresenter.ContentTemplateSelectorProperty, new Binding(nameof(this.ItemTemplateSelector)) { Source = this });
+
+                    if (useVisualSourceItemSizeForDragAdorner)
+                    {
+                        var bounds = VisualTreeExtensions.GetVisibleDescendantBounds(dragInfo.VisualSourceItem);
+                        contentPresenter.SetCurrentValue(MinWidthProperty, bounds.Width);
+                        contentPresenter.SetCurrentValue(MinHeightProperty, bounds.Height);
+                    }
+
+                    contentPresenter.Loaded += this.ContentPresenter_OnLoaded;
+
+                    adornment = contentPresenter;
+                }
+            }
+
+            if (adornment != null && useDefaultDragAdorner)
+            {
+                adornment.Opacity = DragDrop.GetDefaultDragAdornerOpacity(visualSource);
+            }
+
+            return adornment;
+        }
+
+        private void ContentPresenter_OnLoaded(object sender, RoutedEventArgs e)
+        {
+            if (sender is ContentPresenter contentPresenter)
+            {
+                contentPresenter.Loaded -= this.ContentPresenter_OnLoaded;
+
+                // If the template contains a Canvas then we get a strange size.
+                if (this.UseDefaultDragAdorner && this.DragInfo?.VisualSourceItem.GetVisualDescendent<Canvas>() is not null)
+                {
+                    this.VisualSourceItemBounds = this.DragInfo?.VisualSourceItem != null ? VisualTreeHelper.GetDescendantBounds(this.DragInfo.VisualSourceItem) : Rect.Empty;
+
+                    contentPresenter.SetCurrentValue(MaxWidthProperty, this.VisualSourceItemBounds.Width);
+                    contentPresenter.SetCurrentValue(MaxHeightProperty, this.VisualSourceItemBounds.Height);
+                    this.SetCurrentValue(MaxWidthProperty, this.VisualSourceItemBounds.Width);
+                    this.SetCurrentValue(MaxHeightProperty, this.VisualSourceItemBounds.Height);
+                }
+                else
+                {
+                    contentPresenter.ApplyTemplate();
+                    if (contentPresenter.GetVisualDescendent<Canvas>() is not null)
+                    {
+                        // Get the first element and set it's vertical alignment to top.
+                        if (contentPresenter.GetVisualDescendent<DependencyObject>() is FrameworkElement fe)
+                        {
+                            fe.SetCurrentValue(VerticalAlignmentProperty, VerticalAlignment.Top);
+                        }
+
+                        this.VisualSourceItemBounds = this.DragInfo?.VisualSourceItem != null ? VisualTreeHelper.GetDescendantBounds(this.DragInfo.VisualSourceItem) : Rect.Empty;
+
+                        contentPresenter.SetCurrentValue(MaxWidthProperty, this.VisualSourceItemBounds.Width);
+                        contentPresenter.SetCurrentValue(MaxHeightProperty, this.VisualSourceItemBounds.Height);
+                        this.SetCurrentValue(MaxWidthProperty, this.VisualSourceItemBounds.Width);
+                        this.SetCurrentValue(MaxHeightProperty, this.VisualSourceItemBounds.Height);
+                    }
+                }
             }
         }
     }

--- a/src/GongSolutions.WPF.DragDrop/Utilities/DragDropExtensions.cs
+++ b/src/GongSolutions.WPF.DragDrop/Utilities/DragDropExtensions.cs
@@ -120,8 +120,8 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
             {
                 var vb = new VisualBrush(target);
 
-                vb.ViewportUnits = BrushMappingMode.Absolute;
-                vb.Viewport = bounds;
+                // vb.ViewportUnits = BrushMappingMode.Absolute;
+                // vb.Viewport = bounds;
 
                 if (flowDirection == FlowDirection.RightToLeft)
                 {

--- a/src/Showcase/Views/SettingsView.xaml
+++ b/src/Showcase/Views/SettingsView.xaml
@@ -33,6 +33,9 @@
                   Content="UseDefaultDragAdorner"
                   IsChecked="{Binding Path=(dd:DragDrop.UseDefaultDragAdorner), Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
         <CheckBox Margin="10 5 5 5"
+                  Content="UseVisualSourceItemSizeForDragAdorner"
+                  IsChecked="{Binding Path=(dd:DragDrop.UseVisualSourceItemSizeForDragAdorner), Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+        <CheckBox Margin="10 5 5 5"
                   Content="UseDefaultEffectDataTemplate"
                   IsChecked="{Binding Path=(dd:DragDrop.UseDefaultEffectDataTemplate), Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
     </StackPanel>


### PR DESCRIPTION
## What changed?

This PR fixes the issue with the drag preview which doesn't show up if the source is not a target.

_Describe the changes you have made to improve this project._

The preview will now created before the drag operation will be started.

![image](https://user-images.githubusercontent.com/658431/132333677-4b82e424-76b3-4af8-b8c6-bbfaa42e4c67.png)

_Closed issues._

Closes #389 
