### PR TITLE
Enable support for 3rd party controls.

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
@@ -402,6 +402,30 @@ namespace GongSolutions.Wpf.DragDrop
         }
 
         /// <summary>
+        /// Gets or sets the drag info builder for the drag operation.
+        /// </summary>
+        public static readonly DependencyProperty DragInfoBuilderProperty
+            = DependencyProperty.RegisterAttached("DragInfoBuilder",
+                                                  typeof(IDragInfoBuilder),
+                                                  typeof(DragDrop));
+
+        /// <summary>
+        /// Gets the drag info builder for the drag operation.
+        /// </summary>
+        public static IDragInfoBuilder GetDragInfoBuilder(DependencyObject element)
+        {
+            return (IDragInfoBuilder)element.GetValue(DragInfoBuilderProperty);
+        }
+
+        /// <summary>
+        /// Sets the drag info builder for the drag operation.
+        /// </summary>
+        public static void SetDragInfoBuilder(DependencyObject element, IDragInfoBuilder value)
+        {
+            element.SetValue(DragInfoBuilderProperty, value);
+        }
+
+        /// <summary>
         /// Gets or sets the ScrollingMode for the drop operation.
         /// </summary>
         public static readonly DependencyProperty DropScrollingModeProperty

--- a/src/GongSolutions.WPF.DragDrop/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.cs
@@ -275,6 +275,16 @@ namespace GongSolutions.Wpf.DragDrop
         }
 
         /// <summary>
+        /// Gets the drag info builder from the sender.
+        /// </summary>
+        /// <param name="sender">the sender from an event, e.g. drag over</param>
+        /// <returns></returns>
+        private static IDragInfoBuilder TryGetDragInfoBuilder(DependencyObject sender)
+        {
+            return GetDragInfoBuilder(sender);
+        }
+
+        /// <summary>
         /// Gets the RootElementFinder from the sender or uses the default implementation, if it's null.
         /// </summary>
         /// <param name="sender">the sender from an event, e.g. drag over</param>
@@ -344,7 +354,8 @@ namespace GongSolutions.Wpf.DragDrop
                 return;
             }
 
-            var dragInfo = new DragInfo(sender, e);
+            var infoBuilder = TryGetDragInfoBuilder(sender as DependencyObject);
+            var dragInfo = infoBuilder?.CreateDragInfo(sender, e) ?? new DragInfo(sender, e);
 
             DragSourceDown(sender, dragInfo, e);
         }
@@ -365,7 +376,8 @@ namespace GongSolutions.Wpf.DragDrop
                 return;
             }
 
-            var dragInfo = new DragInfo(sender, e);
+            var infoBuilder = TryGetDragInfoBuilder(sender as DependencyObject);
+            var dragInfo = infoBuilder?.CreateDragInfo(sender, e) ?? new DragInfo(sender, e);
 
             DragSourceDown(sender, dragInfo, e);
         }

--- a/src/GongSolutions.WPF.DragDrop/DragInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragInfo.cs
@@ -81,40 +81,40 @@ namespace GongSolutions.Wpf.DragDrop
         public object Data { get; set; }
 
         /// <inheritdoc />
-        public Point DragStartPosition { get; private set; }
+        public Point DragStartPosition { get; protected set; }
 
         /// <inheritdoc />
-        public Point PositionInDraggedItem { get; private set; }
+        public Point PositionInDraggedItem { get; protected set; }
 
         /// <inheritdoc />
         public DragDropEffects Effects { get; set; }
 
         /// <inheritdoc />
-        public MouseButton MouseButton { get; private set; }
+        public MouseButton MouseButton { get; protected set; }
 
         /// <inheritdoc />
-        public IEnumerable SourceCollection { get; private set; }
+        public IEnumerable SourceCollection { get; protected set; }
 
         /// <inheritdoc />
-        public int SourceIndex { get; private set; }
+        public int SourceIndex { get; protected set; }
 
         /// <inheritdoc />
-        public object SourceItem { get; private set; }
+        public object SourceItem { get; protected set; }
 
         /// <inheritdoc />
-        public IEnumerable SourceItems { get; private set; }
+        public IEnumerable SourceItems { get; protected set; }
 
         /// <inheritdoc />
-        public CollectionViewGroup SourceGroup { get; private set; }
+        public CollectionViewGroup SourceGroup { get; protected set; }
 
         /// <inheritdoc />
-        public UIElement VisualSource { get; private set; }
+        public UIElement VisualSource { get; protected set; }
 
         /// <inheritdoc />
-        public UIElement VisualSourceItem { get; private set; }
+        public UIElement VisualSourceItem { get; protected set; }
 
         /// <inheritdoc />
-        public FlowDirection VisualSourceFlowDirection { get; private set; }
+        public FlowDirection VisualSourceFlowDirection { get; protected set; }
 
         /// <inheritdoc />
         public object DataObject { get; set; }
@@ -123,9 +123,9 @@ namespace GongSolutions.Wpf.DragDrop
         public Func<DependencyObject, object, DragDropEffects, DragDropEffects> DragDropHandler { get; set; } = System.Windows.DragDrop.DoDragDrop;
 
         /// <inheritdoc />
-        public DragDropKeyStates DragDropCopyKeyState { get; private set; }
+        public DragDropKeyStates DragDropCopyKeyState { get; protected set; }
 
-        private void InitializeDragInfo(object sender, object originalSource, Func<IInputElement, Point> getPosition)
+        protected virtual void InitializeDragInfo(object sender, object originalSource, Func<IInputElement, Point> getPosition)
         {
             this.Effects = DragDropEffects.None;
             this.VisualSource = sender as UIElement;

--- a/src/GongSolutions.WPF.DragDrop/GongSolutions.WPF.DragDrop.csproj
+++ b/src/GongSolutions.WPF.DragDrop/GongSolutions.WPF.DragDrop.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
     <!-- Project properties -->
     <PropertyGroup>
+        <TargetFramework>net5.0-windows</TargetFramework>
         <AssemblyName>GongSolutions.WPF.DragDrop</AssemblyName>
         <Title>gong-wpf-dragdrop</Title>
         <RootNamespace>GongSolutions.Wpf.DragDrop</RootNamespace>

--- a/src/GongSolutions.WPF.DragDrop/GongSolutions.WPF.DragDrop.csproj
+++ b/src/GongSolutions.WPF.DragDrop/GongSolutions.WPF.DragDrop.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
     <!-- Project properties -->
     <PropertyGroup>
-        <TargetFramework>net5.0-windows</TargetFramework>
         <AssemblyName>GongSolutions.WPF.DragDrop</AssemblyName>
         <Title>gong-wpf-dragdrop</Title>
         <RootNamespace>GongSolutions.Wpf.DragDrop</RootNamespace>

--- a/src/GongSolutions.WPF.DragDrop/IDragInfoBuilder.cs
+++ b/src/GongSolutions.WPF.DragDrop/IDragInfoBuilder.cs
@@ -4,7 +4,7 @@ namespace GongSolutions.Wpf.DragDrop
 {
     /// <summary>
     /// Interface implemented by Drag Info Builders.
-    /// It enables custom construction of DragInfo objects from 3rd party controls like DevExpress, Telerik, etc.
+    /// It enables custom construction of DragInfo objects to support 3rd party controls like DevExpress, Telerik, etc.
     /// </summary>
     public interface IDragInfoBuilder
     {

--- a/src/GongSolutions.WPF.DragDrop/IDragInfoBuilder.cs
+++ b/src/GongSolutions.WPF.DragDrop/IDragInfoBuilder.cs
@@ -1,0 +1,37 @@
+﻿using System.Windows.Input;
+
+namespace GongSolutions.Wpf.DragDrop
+{
+    /// <summary>
+    /// Interface implemented by Drag Info Builders.
+    /// It enables custom construction of DragInfo objects from 3rd party controls like DevExpress, Telerik, etc.
+    /// </summary>
+    public interface IDragInfoBuilder
+    {
+        /// <summary>
+        /// Creates a drag info object from <see cref="MouseButtonEventArgs"/>.
+        /// </summary>
+        /// 
+        /// <param name="sender">
+        /// The sender of the mouse event that initiated the drag.
+        /// </param>
+        /// 
+        /// <param name="e">
+        /// The mouse event that initiated the drag.
+        /// </param>
+        DragInfo CreateDragInfo(object sender, MouseButtonEventArgs e);
+
+        /// <summary>
+        /// Creates a drag info object from <see cref="TouchEventArgs"/>.
+        /// </summary>
+        /// 
+        /// <param name="sender">
+        /// The sender of the touch event that initiated the drag.
+        /// </param>
+        /// 
+        /// <param name="e">
+        /// The touch event that initiated the drag.
+        /// </param>
+        DragInfo CreateDragInfo(object sender, TouchEventArgs e);
+    }
+}


### PR DESCRIPTION
## What changed?
`IDragInfoBuilder` enables the specification of a `IDragInfo` factory to handle unsupported 3rd party controls.
User can opt-in into this interface by adding the right binding in XAML: `dd:DragDrop.DragInfoBuilder="{Binding}"`

Added `IDragInfoBuilder` interface and `DragInfoBuilder` dependency property.
When `IDragInfoBuilder` is specified, the code calls the appropriate member from it to create the DragInfo object. 
If this call returns null, it uses the regular DragInfo construction code. Same thing happens if when IDragInfoBuilder is NOT specified.

`IDragInfoBuilder.CreateDragInfo` is where custom code can be specified to handle the correct creation of DragInfo objects for custom controls.

For instance, I need to support Telerik's RadTreeListView but the same mechanism can be applied to any other 3rd or custom control that is not supported by default.

Closes #36 
