### PR TITLE
Fixes ListBox multi selection & reduces amount of SelectionChanged events

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/Utilities/ItemsControlExtensions.cs
+++ b/src/GongSolutions.WPF.DragDrop/Utilities/ItemsControlExtensions.cs
@@ -340,12 +340,7 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
 
                 if (selectionMode != SelectionMode.Single)
                 {
-                    var itemsToDeselect = listBox.SelectedItems.Cast<object>().Where(si => si != item2Select).ToArray();
-
-                    foreach (var item in itemsToDeselect)
-                    {
-                        listBox.SelectedItems.Remove(item);
-                    }
+                    listBox.UnselectAll();
                 }
 
                 try


### PR DESCRIPTION
## What changed?

This PR addresses the issues raised in #406.

After doing some testing it appears that this bug was introduced with #379. This causes both the excessive amount of `SelectionChanged` events and the issue where you end up with the wrong items selected.

As far as I can tell, the bug where you end up with the wrong items selected, seems to be a WPF bug. This only happens when removing selected items programmatically. It appears that the only way around this issue is to first clear all the selected item(s). As the previous PR was mainly to fix an issue they had with `DataGrid`, in my opinion the best solution is to revert this change for `ListBox`.

Going back to the behavior before #379 works, but setting `SelectionMode` to single, then setting the selected item to null, then setting it to the correct item, causes 3 `SelectionChanged` events. This PR reduces this to 2 events, by instead calling `UnselectAll` first, then setting the selected item.

Fixes #406