### PR TITLE
Enable DropInfo creation for 3rd party controls

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
@@ -426,6 +426,30 @@ namespace GongSolutions.Wpf.DragDrop
         }
 
         /// <summary>
+        /// Gets or sets the drop info builder for the drop operation.
+        /// </summary>
+        public static readonly DependencyProperty DropInfoBuilderProperty
+            = DependencyProperty.RegisterAttached("DropInfoBuilder",
+                                                  typeof(IDropInfoBuilder),
+                                                  typeof(DragDrop));
+
+        /// <summary>
+        /// Gets the drop info builder for the drop operation.
+        /// </summary>
+        public static void SetDropInfoBuilder(DependencyObject element, IDropInfoBuilder value)
+        {
+            element.SetValue(DropInfoBuilderProperty, value);
+        }
+
+        /// <summary>
+        /// Sets the drop info builder for the drop operation.
+        /// </summary>
+        public static IDropInfoBuilder GetDropInfoBuilder(DependencyObject element)
+        {
+            return (IDropInfoBuilder)element.GetValue(DropInfoBuilderProperty);
+        }
+
+        /// <summary>
         /// Gets or sets the ScrollingMode for the drop operation.
         /// </summary>
         public static readonly DependencyProperty DropScrollingModeProperty

--- a/src/GongSolutions.WPF.DragDrop/DropTargetAdorner.cs
+++ b/src/GongSolutions.WPF.DragDrop/DropTargetAdorner.cs
@@ -7,7 +7,7 @@ namespace GongSolutions.Wpf.DragDrop
 {
     public abstract class DropTargetAdorner : Adorner
     {
-        public DropTargetAdorner(UIElement adornedElement, DropInfo dropInfo)
+        public DropTargetAdorner(UIElement adornedElement, IDropInfo dropInfo)
             : base(adornedElement)
         {
             this.DropInfo = dropInfo;
@@ -18,7 +18,7 @@ namespace GongSolutions.Wpf.DragDrop
             this.m_AdornerLayer.Add(this);
         }
 
-        public DropInfo DropInfo { get; set; }
+        public IDropInfo DropInfo { get; set; }
 
         /// <summary>
         /// Gets or Sets the pen which can be used for the render process.

--- a/src/GongSolutions.WPF.DragDrop/IDropInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop/IDropInfo.cs
@@ -88,6 +88,16 @@ namespace GongSolutions.Wpf.DragDrop
         CollectionViewGroup TargetGroup { get; }
 
         /// <summary>
+        /// Gets the ScrollViewer control for the visual target.
+        /// </summary>
+        ScrollViewer TargetScrollViewer { get; }
+
+        /// <summary>
+        /// Gets or Sets the ScrollingMode for the drop action.
+        /// </summary>
+        ScrollingMode TargetScrollingMode { get; }
+
+        /// <summary>
         /// Gets the control that is the current drop target.
         /// </summary>
         UIElement VisualTarget { get; }

--- a/src/GongSolutions.WPF.DragDrop/IDropInfoBuilder.cs
+++ b/src/GongSolutions.WPF.DragDrop/IDropInfoBuilder.cs
@@ -1,0 +1,33 @@
+using System.Windows;
+using JetBrains.Annotations;
+
+namespace GongSolutions.Wpf.DragDrop
+{
+    /// <summary>
+    /// Interface implemented by Drop Info Builders.
+    /// It enables custom construction of IDropInfo objects to support 3rd party controls like DevExpress, Telerik, etc.
+    /// </summary>
+    public interface IDropInfoBuilder
+    {
+        /// <summary>
+        /// Creates a drop info object from <see cref="DragEventArgs"/> and <see cref="DragInfo"/>.
+        /// </summary>
+        ///
+        /// <param name="sender">
+        /// The sender of the mouse event that initiated the drag.
+        /// </param>
+        /// 
+        /// <param name="e">
+        /// The drag event args that initiated the drag.
+        /// </param>
+        ///
+        /// <param name="dragInfo">
+        /// Object which contains the drag information.
+        /// </param>
+        ///
+        /// <param name="eventType">
+        /// The mode of the underlying routed event.
+        /// </param>
+        [CanBeNull] IDropInfo CreateDropInfo(object sender, [CanBeNull] DragEventArgs e, DragInfo dragInfo, EventType eventType);
+    }
+}


### PR DESCRIPTION
`IDropInfoBuilder` enables the specification of a `IDropInfo` factory to handle unsupported 3rd party controls.
User can opt-in into this interface by adding the right binding in XAML: `dd:DragDrop.DropInfoBuilder="{Binding}"`

Added `IDropInfoBuilder` interface and `DropInfoBuilder` dependency property.
When `IDropInfoBuilder` is specified, the code calls the appropriate member from it to create the DrapInfo object.
If this call returns null, it uses the regular DropInfo construction code. Same thing happens if when IDropInfoBuilder is NOT specified.

`IDropInfoBuilder.CreateDropInfo` is where custom code can be specified to handle the correct creation of DropInfo objects for custom controls.

For instance, I need to support Telerik's RadTreeListView but the same mechanism can be applied to any other 3rd or custom control that is not supported by default.
