### PR TITLE
Simplify IDragInfoBuilder and update documentation

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.cs
@@ -357,7 +357,8 @@ namespace GongSolutions.Wpf.DragDrop
             }
 
             var infoBuilder = TryGetDragInfoBuilder(sender as DependencyObject);
-            var dragInfo = infoBuilder?.CreateDragInfo(sender, e) ?? new DragInfo(sender, e);
+            var dragInfo = infoBuilder?.CreateDragInfo(sender, e.OriginalSource, MouseButton.Left, item => e.GetTouchPoint(item).Position)
+                           ?? new DragInfo(sender, e.OriginalSource, MouseButton.Left, item => e.GetTouchPoint(item).Position);
 
             DragSourceDown(sender, dragInfo, e);
         }
@@ -379,7 +380,8 @@ namespace GongSolutions.Wpf.DragDrop
             }
 
             var infoBuilder = TryGetDragInfoBuilder(sender as DependencyObject);
-            var dragInfo = infoBuilder?.CreateDragInfo(sender, e) ?? new DragInfo(sender, e);
+            var dragInfo = infoBuilder?.CreateDragInfo(sender, e.OriginalSource, e.ChangedButton, item => e.GetPosition(item))
+                           ?? new DragInfo(sender, e.OriginalSource, e.ChangedButton, item => e.GetPosition(item));
 
             DragSourceDown(sender, dragInfo, e);
         }

--- a/src/GongSolutions.WPF.DragDrop/DragInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragInfo.cs
@@ -20,60 +20,6 @@ namespace GongSolutions.Wpf.DragDrop
     /// </remarks>
     public class DragInfo : IDragInfo
     {
-        /// <summary>
-        /// Initializes a new instance of the DragInfo class.
-        /// </summary>
-        /// 
-        /// <param name="sender">
-        /// The sender of the mouse event that initiated the drag.
-        /// </param>
-        /// 
-        /// <param name="e">
-        /// The mouse event that initiated the drag.
-        /// </param>
-        public DragInfo(object sender, MouseButtonEventArgs e)
-        {
-            this.InitializeDragInfo(sender, e.OriginalSource, item => e.GetPosition(item));
-            this.MouseButton = e.ChangedButton;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the DragInfo class.
-        /// </summary>
-        /// 
-        /// <param name="sender">
-        /// The sender of the mouse event that initiated the drag.
-        /// </param>
-        /// 
-        /// <param name="e">
-        /// The touch event that initiated the drag.
-        /// </param>
-        public DragInfo(object sender, TouchEventArgs e)
-        {
-            this.InitializeDragInfo(sender, e.OriginalSource, item => e.GetTouchPoint(item).Position);
-        }
-
-        internal void RefreshSelectedItems(object sender)
-        {
-            if (sender is ItemsControl)
-            {
-                var itemsControl = (ItemsControl)sender;
-
-                var selectedItems = itemsControl.GetSelectedItems().OfType<object>().Where(i => i != CollectionView.NewItemPlaceholder).ToList();
-                this.SourceItems = selectedItems;
-
-                // Some controls (I'm looking at you TreeView!) haven't updated their
-                // SelectedItem by this point. Check to see if there 1 or less item in 
-                // the SourceItems collection, and if so, override the control's SelectedItems with the clicked item.
-                //
-                // The control has still the old selected items at the mouse down event, so we should check this and give only the real selected item to the user.
-                if (selectedItems.Count <= 1 || this.SourceItem != null && !selectedItems.Contains(this.SourceItem))
-                {
-                    this.SourceItems = Enumerable.Repeat(this.SourceItem, 1);
-                }
-            }
-        }
-
         /// <inheritdoc />
         public DataFormat DataFormat { get; set; } = DragDrop.DataFormat;
 
@@ -125,8 +71,16 @@ namespace GongSolutions.Wpf.DragDrop
         /// <inheritdoc />
         public DragDropKeyStates DragDropCopyKeyState { get; protected set; }
 
-        protected virtual void InitializeDragInfo(object sender, object originalSource, Func<IInputElement, Point> getPosition)
+        /// <summary>
+        /// Initializes a new instance of the DragInfo class.
+        /// </summary>
+        /// <param name="sender">The sender of the input event that initiated the drag operation.</param>
+        /// <param name="originalSource">The original source of the input event.</param>
+        /// <param name="mouseButton">The mouse button which was used for the drag operation.</param>
+        /// <param name="getPosition">A function of the input event which is used to get drag position points.</param>
+        public DragInfo(object sender, object originalSource, MouseButton mouseButton, Func<IInputElement, Point> getPosition)
         {
+            this.MouseButton = mouseButton;
             this.Effects = DragDropEffects.None;
             this.VisualSource = sender as UIElement;
             this.DragStartPosition = getPosition(this.VisualSource);
@@ -158,7 +112,7 @@ namespace GongSolutions.Wpf.DragDrop
 
                 if (item == null)
                 {
-                    var itemPosition = getPosition(itemsControl);
+                    var itemPosition = this.DragStartPosition;
 
                     if (DragDrop.GetDragDirectlySelectedOnly(this.VisualSource))
                     {
@@ -201,6 +155,7 @@ namespace GongSolutions.Wpf.DragDrop
                                 return;
                             }
                         }
+
                         this.SourceIndex = itemParent.ItemContainerGenerator.IndexFromContainer(item);
                         this.SourceItem = itemParent.ItemContainerGenerator.ItemFromContainer(item);
                     }
@@ -236,6 +191,7 @@ namespace GongSolutions.Wpf.DragDrop
                 {
                     this.SourceItems = Enumerable.Repeat(this.SourceItem, 1);
                 }
+
                 this.VisualSourceItem = sourceElement;
                 this.PositionInDraggedItem = sourceElement != null ? getPosition(sourceElement) : this.DragStartPosition;
             }
@@ -243,6 +199,27 @@ namespace GongSolutions.Wpf.DragDrop
             if (this.SourceItems == null)
             {
                 this.SourceItems = Enumerable.Empty<object>();
+            }
+        }
+
+        internal void RefreshSelectedItems(object sender)
+        {
+            if (sender is ItemsControl)
+            {
+                var itemsControl = (ItemsControl)sender;
+
+                var selectedItems = itemsControl.GetSelectedItems().OfType<object>().Where(i => i != CollectionView.NewItemPlaceholder).ToList();
+                this.SourceItems = selectedItems;
+
+                // Some controls (I'm looking at you TreeView!) haven't updated their
+                // SelectedItem by this point. Check to see if there 1 or less item in 
+                // the SourceItems collection, and if so, override the control's SelectedItems with the clicked item.
+                //
+                // The control has still the old selected items at the mouse down event, so we should check this and give only the real selected item to the user.
+                if (selectedItems.Count <= 1 || this.SourceItem != null && !selectedItems.Contains(this.SourceItem))
+                {
+                    this.SourceItems = Enumerable.Repeat(this.SourceItem, 1);
+                }
             }
         }
     }

--- a/src/GongSolutions.WPF.DragDrop/DropInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop/DropInfo.cs
@@ -24,26 +24,141 @@ namespace GongSolutions.Wpf.DragDrop
         private ItemsControl itemParent = null;
         private UIElement item = null;
 
+        /// <inheritdoc />
+        public object Data { get; set; }
+
+        /// <inheritdoc />
+        public IDragInfo DragInfo { get; private set; }
+
+        /// <inheritdoc />
+        public Point DropPosition { get; private set; }
+
+        /// <inheritdoc />
+        public Type DropTargetAdorner { get; set; }
+
+        /// <inheritdoc />
+        public DragDropEffects Effects { get; set; }
+
+        /// <inheritdoc />
+        public int InsertIndex { get; private set; }
+
+        /// <inheritdoc />
+        public int UnfilteredInsertIndex
+        {
+            get
+            {
+                var insertIndex = this.InsertIndex;
+                if (itemParent != null)
+                {
+                    var itemSourceAsList = itemParent.ItemsSource.TryGetList();
+                    if (itemSourceAsList != null && itemParent.Items != null && itemParent.Items.Count != itemSourceAsList.Count)
+                    {
+                        if (insertIndex >= 0 && insertIndex < itemParent.Items.Count)
+                        {
+                            var indexOf = itemSourceAsList.IndexOf(itemParent.Items[insertIndex]);
+                            if (indexOf >= 0)
+                            {
+                                return indexOf;
+                            }
+                        }
+                        else if (itemParent.Items.Count > 0 && insertIndex == itemParent.Items.Count)
+                        {
+                            var indexOf = itemSourceAsList.IndexOf(itemParent.Items[insertIndex - 1]);
+                            if (indexOf >= 0)
+                            {
+                                return indexOf + 1;
+                            }
+                        }
+                    }
+                }
+
+                return insertIndex;
+            }
+        }
+
+        /// <inheritdoc />
+        public IEnumerable TargetCollection { get; private set; }
+
+        /// <inheritdoc />
+        public object TargetItem { get; private set; }
+
+        /// <inheritdoc />
+        public CollectionViewGroup TargetGroup { get; private set; }
+
+        /// <summary>
+        /// Gets the ScrollViewer control for the visual target.
+        /// </summary>
+        public ScrollViewer TargetScrollViewer { get; private set; }
+
+        /// <summary>
+        /// Gets or Sets the ScrollingMode for the drop action.
+        /// </summary>
+        public ScrollingMode TargetScrollingMode { get; set; }
+
+        /// <inheritdoc />
+        public UIElement VisualTarget { get; private set; }
+
+        /// <inheritdoc />
+        public UIElement VisualTargetItem { get; private set; }
+
+        /// <inheritdoc />
+        public Orientation VisualTargetOrientation { get; private set; }
+
+        /// <inheritdoc />
+        public FlowDirection VisualTargetFlowDirection { get; private set; }
+
+        /// <inheritdoc />
+        public string DestinationText { get; set; }
+
+        /// <inheritdoc />
+        public string EffectText { get; set; }
+
+        /// <inheritdoc />
+        public RelativeInsertPosition InsertPosition { get; private set; }
+
+        /// <inheritdoc />
+        public DragDropKeyStates KeyStates { get; private set; }
+
+        /// <inheritdoc />
+        public bool NotHandled { get; set; }
+
+        /// <inheritdoc />
+        public bool IsSameDragDropContextAsSource
+        {
+            get
+            {
+                // Check if DragInfo stuff exists
+                if (this.DragInfo?.VisualSource is null)
+                {
+                    return true;
+                }
+
+                // A target should be exists
+                if (this.VisualTarget is null)
+                {
+                    return true;
+                }
+
+                // Source element has a drag context constraint, we need to check the target property matches.
+                var sourceContext = DragDrop.GetDragDropContext(this.DragInfo.VisualSource);
+                var targetContext = DragDrop.GetDragDropContext(this.VisualTarget);
+
+                return string.Equals(sourceContext, targetContext)
+                       || string.IsNullOrEmpty(targetContext);
+            }
+        }
+
+        /// <inheritdoc />
+        public EventType EventType { get; }
+
         /// <summary>
         /// Initializes a new instance of the DropInfo class.
         /// </summary>
-        /// 
-        /// <param name="sender">
-        /// The sender of the drag event.
-        /// </param>
-        /// 
-        /// <param name="e">
-        /// The drag event.
-        /// </param>
-        /// 
-        /// <param name="dragInfo">
-        /// Information about the source of the drag, if the drag came from within the framework.
-        /// </param>
-        /// 
-        /// <param name="eventType">
-        /// The type of the underlying event (tunneled or bubbled).
-        /// </param>
-        public DropInfo(object sender, DragEventArgs e, [CanBeNull] DragInfo dragInfo, EventType eventType)
+        /// <param name="sender">The sender of the drop event.</param>
+        /// <param name="e">The drag event arguments.</param>
+        /// <param name="dragInfo">Information about the drag source, if the drag came from within the framework.</param>
+        /// <param name="eventType">The type of the underlying event (tunneled or bubbled).</param>
+        public DropInfo(object sender, DragEventArgs e, [CanBeNull] IDragInfo dragInfo, EventType eventType)
         {
             this.DragInfo = dragInfo;
             this.KeyStates = e.KeyStates;
@@ -238,133 +353,6 @@ namespace GongSolutions.Wpf.DragDrop
                 this.VisualTargetItem = this.VisualTarget;
             }
         }
-
-        /// <inheritdoc />
-        public object Data { get; set; }
-
-        /// <inheritdoc />
-        public IDragInfo DragInfo { get; private set; }
-
-        /// <inheritdoc />
-        public Point DropPosition { get; private set; }
-
-        /// <inheritdoc />
-        public Type DropTargetAdorner { get; set; }
-
-        /// <inheritdoc />
-        public DragDropEffects Effects { get; set; }
-
-        /// <inheritdoc />
-        public int InsertIndex { get; private set; }
-
-        /// <inheritdoc />
-        public int UnfilteredInsertIndex
-        {
-            get
-            {
-                var insertIndex = this.InsertIndex;
-                if (itemParent != null)
-                {
-                    var itemSourceAsList = itemParent.ItemsSource.TryGetList();
-                    if (itemSourceAsList != null && itemParent.Items != null && itemParent.Items.Count != itemSourceAsList.Count)
-                    {
-                        if (insertIndex >= 0 && insertIndex < itemParent.Items.Count)
-                        {
-                            var indexOf = itemSourceAsList.IndexOf(itemParent.Items[insertIndex]);
-                            if (indexOf >= 0)
-                            {
-                                return indexOf;
-                            }
-                        }
-                        else if (itemParent.Items.Count > 0 && insertIndex == itemParent.Items.Count)
-                        {
-                            var indexOf = itemSourceAsList.IndexOf(itemParent.Items[insertIndex - 1]);
-                            if (indexOf >= 0)
-                            {
-                                return indexOf + 1;
-                            }
-                        }
-                    }
-                }
-
-                return insertIndex;
-            }
-        }
-
-        /// <inheritdoc />
-        public IEnumerable TargetCollection { get; private set; }
-
-        /// <inheritdoc />
-        public object TargetItem { get; private set; }
-
-        /// <inheritdoc />
-        public CollectionViewGroup TargetGroup { get; private set; }
-
-        /// <summary>
-        /// Gets the ScrollViewer control for the visual target.
-        /// </summary>
-        public ScrollViewer TargetScrollViewer { get; private set; }
-
-        /// <summary>
-        /// Gets or Sets the ScrollingMode for the drop action.
-        /// </summary>
-        public ScrollingMode TargetScrollingMode { get; set; }
-
-        /// <inheritdoc />
-        public UIElement VisualTarget { get; private set; }
-
-        /// <inheritdoc />
-        public UIElement VisualTargetItem { get; private set; }
-
-        /// <inheritdoc />
-        public Orientation VisualTargetOrientation { get; private set; }
-
-        /// <inheritdoc />
-        public FlowDirection VisualTargetFlowDirection { get; private set; }
-
-        /// <inheritdoc />
-        public string DestinationText { get; set; }
-
-        /// <inheritdoc />
-        public string EffectText { get; set; }
-
-        /// <inheritdoc />
-        public RelativeInsertPosition InsertPosition { get; private set; }
-
-        /// <inheritdoc />
-        public DragDropKeyStates KeyStates { get; private set; }
-
-        /// <inheritdoc />
-        public bool NotHandled { get; set; }
-
-        /// <inheritdoc />
-        public bool IsSameDragDropContextAsSource
-        {
-            get
-            {
-                // Check if DragInfo stuff exists
-                if (this.DragInfo?.VisualSource is null)
-                {
-                    return true;
-                }
-
-                // A target should be exists
-                if (this.VisualTarget is null)
-                {
-                    return true;
-                }
-
-                // Source element has a drag context constraint, we need to check the target property matches.
-                var sourceContext = DragDrop.GetDragDropContext(this.DragInfo.VisualSource);
-                var targetContext = DragDrop.GetDragDropContext(this.VisualTarget);
-
-                return string.Equals(sourceContext, targetContext)
-                       || string.IsNullOrEmpty(targetContext);
-            }
-        }
-
-        /// <inheritdoc />
-        public EventType EventType { get; }
     }
 
     [Flags]

--- a/src/GongSolutions.WPF.DragDrop/IDragInfoBuilder.cs
+++ b/src/GongSolutions.WPF.DragDrop/IDragInfoBuilder.cs
@@ -1,4 +1,7 @@
-﻿using System.Windows.Input;
+﻿using System;
+using System.Windows;
+using System.Windows.Input;
+using JetBrains.Annotations;
 
 namespace GongSolutions.Wpf.DragDrop
 {
@@ -9,29 +12,13 @@ namespace GongSolutions.Wpf.DragDrop
     public interface IDragInfoBuilder
     {
         /// <summary>
-        /// Creates a drag info object from <see cref="MouseButtonEventArgs"/>.
+        /// Initializes a new instance of the DragInfo class.
         /// </summary>
-        /// 
-        /// <param name="sender">
-        /// The sender of the mouse event that initiated the drag.
-        /// </param>
-        /// 
-        /// <param name="e">
-        /// The mouse event that initiated the drag.
-        /// </param>
-        DragInfo CreateDragInfo(object sender, MouseButtonEventArgs e);
-
-        /// <summary>
-        /// Creates a drag info object from <see cref="TouchEventArgs"/>.
-        /// </summary>
-        /// 
-        /// <param name="sender">
-        /// The sender of the touch event that initiated the drag.
-        /// </param>
-        /// 
-        /// <param name="e">
-        /// The touch event that initiated the drag.
-        /// </param>
-        DragInfo CreateDragInfo(object sender, TouchEventArgs e);
+        /// <param name="sender">The sender of the input event that initiated the drag operation.</param>
+        /// <param name="originalSource">The original source of the input event.</param>
+        /// <param name="mouseButton">The mouse button which was used for the drag operation.</param>
+        /// <param name="getPosition">A function of the input event which is used to get drag position points.</param>
+        [CanBeNull]
+        DragInfo CreateDragInfo(object sender, object originalSource, MouseButton mouseButton, Func<IInputElement, Point> getPosition);
     }
 }

--- a/src/GongSolutions.WPF.DragDrop/IDropInfoBuilder.cs
+++ b/src/GongSolutions.WPF.DragDrop/IDropInfoBuilder.cs
@@ -10,25 +10,13 @@ namespace GongSolutions.Wpf.DragDrop
     public interface IDropInfoBuilder
     {
         /// <summary>
-        /// Creates a drop info object from <see cref="DragEventArgs"/> and <see cref="DragInfo"/>.
+        /// Initializes a new instance of the DropInfo class.
         /// </summary>
-        ///
-        /// <param name="sender">
-        /// The sender of the mouse event that initiated the drag.
-        /// </param>
-        /// 
-        /// <param name="e">
-        /// The drag event args that initiated the drag.
-        /// </param>
-        ///
-        /// <param name="dragInfo">
-        /// Object which contains the drag information.
-        /// </param>
-        ///
-        /// <param name="eventType">
-        /// The mode of the underlying routed event.
-        /// </param>
+        /// <param name="sender">The sender of the drop event.</param>
+        /// <param name="e">The drag event arguments.</param>
+        /// <param name="dragInfo">Information about the drag source, if the drag came from within the framework.</param>
+        /// <param name="eventType">The type of the underlying event (tunneled or bubbled).</param>
         [CanBeNull]
-        IDropInfo CreateDropInfo(object sender, [CanBeNull] DragEventArgs e, DragInfo dragInfo, EventType eventType);
+        IDropInfo CreateDropInfo(object sender, DragEventArgs e, [CanBeNull] DragInfo dragInfo, EventType eventType);
     }
 }


### PR DESCRIPTION
## What changed?

- Simplify IDragInfoBuilder creation
- Update documentation of IDropInfoBuilder

**_IDragInfoBuilder_**
```csharp
/// <summary>
/// Interface implemented by Drag Info Builders.
/// It enables custom construction of DragInfo objects to support 3rd party controls like DevExpress, Telerik, etc.
/// </summary>
public interface IDragInfoBuilder
{
    /// <summary>
    /// Initializes a new instance of the DragInfo class.
    /// </summary>
    /// <param name="sender">The sender of the input event that initiated the drag operation.</param>
    /// <param name="originalSource">The original source of the input event.</param>
    /// <param name="mouseButton">The mouse button which was used for the drag operation.</param>
    /// <param name="getPosition">A function of the input event which is used to get drag position points.</param>
    [CanBeNull]
    DragInfo CreateDragInfo(object sender, object originalSource, MouseButton mouseButton, Func<IInputElement, Point> getPosition);
}
```

**_IDropInfoBuilder_**
```csharp
/// <summary>
/// Interface implemented by Drop Info Builders.
/// It enables custom construction of IDropInfo objects to support 3rd party controls like DevExpress, Telerik, etc.
/// </summary>
public interface IDropInfoBuilder
{
    /// <summary>
    /// Initializes a new instance of the DropInfo class.
    /// </summary>
    /// <param name="sender">The sender of the drop event.</param>
    /// <param name="e">The drag event arguments.</param>
    /// <param name="dragInfo">Information about the drag source, if the drag came from within the framework.</param>
    /// <param name="eventType">The type of the underlying event (tunneled or bubbled).</param>
    [CanBeNull]
    IDropInfo CreateDropInfo(object sender, DragEventArgs e, [CanBeNull] DragInfo dragInfo, EventType eventType);
}
```
