### PR TITLE
Add DragAdorner and DropAdorner DataTemplate/Selector for multiple item selection

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
@@ -865,34 +865,6 @@ namespace GongSolutions.Wpf.DragDrop
         }
 
         /// <summary>
-        /// Gets or sets a DataTemplate for the DragAdorner based on the DropTarget.
-        /// </summary>
-        public static readonly DependencyProperty DropAdornerTemplateProperty
-            = DependencyProperty.RegisterAttached("DropAdornerTemplate",
-                                                  typeof(DataTemplate),
-                                                  typeof(DragDrop));
-
-        /// <summary>Helper for getting <see cref="DropAdornerTemplateProperty"/> from <paramref name="element"/>.</summary>
-        /// <param name="element"><see cref="DependencyObject"/> to read <see cref="DropAdornerTemplateProperty"/> from.</param>
-        /// <remarks>Gets the DataTemplate for the DragAdorner based on the DropTarget.</remarks>
-        /// <returns>DropAdornerTemplate property value.</returns>
-        [AttachedPropertyBrowsableForType(typeof(UIElement))]
-        public static DataTemplate GetDropAdornerTemplate(DependencyObject element)
-        {
-            return (DataTemplate)element.GetValue(DropAdornerTemplateProperty);
-        }
-
-        /// <summary>Helper for setting <see cref="DropAdornerTemplateProperty"/> on <paramref name="element"/>.</summary>
-        /// <param name="element"><see cref="DependencyObject"/> to set <see cref="DropAdornerTemplateProperty"/> on.</param>
-        /// <param name="value">DropAdornerTemplate property value.</param>
-        /// <remarks>Sets the DataTemplate for the DragAdorner based on the DropTarget.</remarks>
-        [AttachedPropertyBrowsableForType(typeof(UIElement))]
-        public static void SetDropAdornerTemplate(DependencyObject element, DataTemplate value)
-        {
-            element.SetValue(DropAdornerTemplateProperty, value);
-        }
-
-        /// <summary>
         /// Gets or sets a DataTemplateSelector for the DragAdorner.
         /// </summary>
         public static readonly DependencyProperty DragAdornerTemplateSelectorProperty
@@ -919,6 +891,63 @@ namespace GongSolutions.Wpf.DragDrop
         public static void SetDragAdornerTemplateSelector(DependencyObject element, DataTemplateSelector value)
         {
             element.SetValue(DragAdornerTemplateSelectorProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a DragAdorner DataTemplate for multiple item selection.
+        /// </summary>
+        public static readonly DependencyProperty DragAdornerMultiItemTemplateProperty
+            = DependencyProperty.RegisterAttached("DragAdornerMultiItemTemplate",
+                                                  typeof(DataTemplate),
+                                                  typeof(DragDrop));
+
+        /// <summary>Helper for getting <see cref="DragAdornerMultiItemTemplateProperty"/> from <paramref name="element"/>.</summary>
+        /// <param name="element"><see cref="DependencyObject"/> to read <see cref="DragAdornerMultiItemTemplateProperty"/> from.</param>
+        /// <remarks>Gets the DragAdorner DataTemplate for multiple item selection.</remarks>
+        /// <returns>DragAdornerMultiItemTemplate property value.</returns>
+        [AttachedPropertyBrowsableForType(typeof(UIElement))]
+        public static DataTemplate GetDragAdornerMultiItemTemplate(DependencyObject element)
+        {
+            return (DataTemplate)element.GetValue(DragAdornerMultiItemTemplateProperty);
+        }
+
+        /// <summary>Helper for setting <see cref="DragAdornerMultiItemTemplateProperty"/> on <paramref name="element"/>.</summary>
+        /// <param name="element"><see cref="DependencyObject"/> to set <see cref="DragAdornerMultiItemTemplateProperty"/> on.</param>
+        /// <param name="value">DragAdornerMultiItemTemplate property value.</param>
+        /// <remarks>Sets the DragAdorner DataTemplate for multiple item selection.</remarks>
+        [AttachedPropertyBrowsableForType(typeof(UIElement))]
+        public static void SetDragAdornerMultiItemTemplate(DependencyObject element, DataTemplate value)
+        {
+            element.SetValue(DragAdornerMultiItemTemplateProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a DragAdorner DataTemplateSelector for multiple item selection.
+        /// </summary>
+        public static readonly DependencyProperty DragAdornerMultiItemTemplateSelectorProperty
+            = DependencyProperty.RegisterAttached("DragAdornerMultiItemTemplateSelector",
+                                                  typeof(DataTemplateSelector),
+                                                  typeof(DragDrop),
+                                                  new PropertyMetadata(default(DataTemplateSelector)));
+
+        /// <summary>Helper for getting <see cref="DragAdornerMultiItemTemplateSelectorProperty"/> from <paramref name="element"/>.</summary>
+        /// <param name="element"><see cref="DependencyObject"/> to read <see cref="DragAdornerMultiItemTemplateSelectorProperty"/> from.</param>
+        /// <remarks>Gets the DragAdorner DataTemplateSelector for multiple item selection.</remarks>
+        /// <returns>DragAdornerMultiItemTemplateSelector property value.</returns>
+        [AttachedPropertyBrowsableForType(typeof(UIElement))]
+        public static DataTemplateSelector GetDragAdornerMultiItemTemplateSelector(DependencyObject element)
+        {
+            return (DataTemplateSelector)element.GetValue(DragAdornerMultiItemTemplateSelectorProperty);
+        }
+
+        /// <summary>Helper for setting <see cref="DragAdornerMultiItemTemplateSelectorProperty"/> on <paramref name="element"/>.</summary>
+        /// <param name="element"><see cref="DependencyObject"/> to set <see cref="DragAdornerMultiItemTemplateSelectorProperty"/> on.</param>
+        /// <param name="value">DragAdornerMultiItemTemplateSelector property value.</param>
+        /// <remarks>Sets the DragAdorner DataTemplateSelector for multiple item selection.</remarks>
+        [AttachedPropertyBrowsableForType(typeof(UIElement))]
+        public static void SetDragAdornerMultiItemTemplateSelector(DependencyObject element, DataTemplateSelector value)
+        {
+            element.SetValue(DragAdornerMultiItemTemplateSelectorProperty, value);
         }
 
         /// <summary>
@@ -951,6 +980,34 @@ namespace GongSolutions.Wpf.DragDrop
         }
 
         /// <summary>
+        /// Gets or sets a DataTemplate for the DragAdorner based on the DropTarget.
+        /// </summary>
+        public static readonly DependencyProperty DropAdornerTemplateProperty
+            = DependencyProperty.RegisterAttached("DropAdornerTemplate",
+                                                  typeof(DataTemplate),
+                                                  typeof(DragDrop));
+
+        /// <summary>Helper for getting <see cref="DropAdornerTemplateProperty"/> from <paramref name="element"/>.</summary>
+        /// <param name="element"><see cref="DependencyObject"/> to read <see cref="DropAdornerTemplateProperty"/> from.</param>
+        /// <remarks>Gets the DataTemplate for the DragAdorner based on the DropTarget.</remarks>
+        /// <returns>DropAdornerTemplate property value.</returns>
+        [AttachedPropertyBrowsableForType(typeof(UIElement))]
+        public static DataTemplate GetDropAdornerTemplate(DependencyObject element)
+        {
+            return (DataTemplate)element.GetValue(DropAdornerTemplateProperty);
+        }
+
+        /// <summary>Helper for setting <see cref="DropAdornerTemplateProperty"/> on <paramref name="element"/>.</summary>
+        /// <param name="element"><see cref="DependencyObject"/> to set <see cref="DropAdornerTemplateProperty"/> on.</param>
+        /// <param name="value">DropAdornerTemplate property value.</param>
+        /// <remarks>Sets the DataTemplate for the DragAdorner based on the DropTarget.</remarks>
+        [AttachedPropertyBrowsableForType(typeof(UIElement))]
+        public static void SetDropAdornerTemplate(DependencyObject element, DataTemplate value)
+        {
+            element.SetValue(DropAdornerTemplateProperty, value);
+        }
+
+        /// <summary>
         /// Gets or sets a DataTemplateSelector for the DragAdorner based on the DropTarget.
         /// </summary>
         public static readonly DependencyProperty DropAdornerTemplateSelectorProperty
@@ -977,6 +1034,63 @@ namespace GongSolutions.Wpf.DragDrop
         public static void SetDropAdornerTemplateSelector(DependencyObject element, DataTemplateSelector value)
         {
             element.SetValue(DropAdornerTemplateSelectorProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a DropAdorner DataTemplate for multiple item selection.
+        /// </summary>
+        public static readonly DependencyProperty DropAdornerMultiItemTemplateProperty
+            = DependencyProperty.RegisterAttached("DropAdornerMultiItemTemplate",
+                                                  typeof(DataTemplate),
+                                                  typeof(DragDrop));
+
+        /// <summary>Helper for getting <see cref="DropAdornerMultiItemTemplateProperty"/> from <paramref name="element"/>.</summary>
+        /// <param name="element"><see cref="DependencyObject"/> to read <see cref="DropAdornerMultiItemTemplateProperty"/> from.</param>
+        /// <remarks>Gets the DropAdorner DataTemplate for multiple item selection.</remarks>
+        /// <returns>DropAdornerMultiItemTemplate property value.</returns>
+        [AttachedPropertyBrowsableForType(typeof(UIElement))]
+        public static DataTemplate GetDropAdornerMultiItemTemplate(DependencyObject element)
+        {
+            return (DataTemplate)element.GetValue(DropAdornerMultiItemTemplateProperty);
+        }
+
+        /// <summary>Helper for setting <see cref="DropAdornerMultiItemTemplateProperty"/> on <paramref name="element"/>.</summary>
+        /// <param name="element"><see cref="DependencyObject"/> to set <see cref="DropAdornerMultiItemTemplateProperty"/> on.</param>
+        /// <param name="value">DropAdornerMultiItemTemplate property value.</param>
+        /// <remarks>Sets the DropAdorner DataTemplate for multiple item selection.</remarks>
+        [AttachedPropertyBrowsableForType(typeof(UIElement))]
+        public static void SetDropAdornerMultiItemTemplate(DependencyObject element, DataTemplate value)
+        {
+            element.SetValue(DropAdornerMultiItemTemplateProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a DropAdorner DataTemplateSelector for multiple item selection.
+        /// </summary>
+        public static readonly DependencyProperty DropAdornerMultiItemTemplateSelectorProperty
+            = DependencyProperty.RegisterAttached("DropAdornerMultiItemTemplateSelector",
+                                                  typeof(DataTemplateSelector),
+                                                  typeof(DragDrop),
+                                                  new PropertyMetadata(default(DataTemplateSelector)));
+
+        /// <summary>Helper for getting <see cref="DropAdornerMultiItemTemplateSelectorProperty"/> from <paramref name="element"/>.</summary>
+        /// <param name="element"><see cref="DependencyObject"/> to read <see cref="DropAdornerMultiItemTemplateSelectorProperty"/> from.</param>
+        /// <remarks>Gets the DropAdorner DataTemplateSelector for multiple item selection.</remarks>
+        /// <returns>DropAdornerMultiItemTemplateSelector property value.</returns>
+        [AttachedPropertyBrowsableForType(typeof(UIElement))]
+        public static DataTemplateSelector GetDropAdornerMultiItemTemplateSelector(DependencyObject element)
+        {
+            return (DataTemplateSelector)element.GetValue(DropAdornerMultiItemTemplateSelectorProperty);
+        }
+
+        /// <summary>Helper for setting <see cref="DropAdornerMultiItemTemplateSelectorProperty"/> on <paramref name="element"/>.</summary>
+        /// <param name="element"><see cref="DependencyObject"/> to set <see cref="DropAdornerMultiItemTemplateSelectorProperty"/> on.</param>
+        /// <param name="value">DropAdornerMultiItemTemplateSelector property value.</param>
+        /// <remarks>Sets the DropAdorner DataTemplateSelector for multiple item selection.</remarks>
+        [AttachedPropertyBrowsableForType(typeof(UIElement))]
+        public static void SetDropAdornerMultiItemTemplateSelector(DependencyObject element, DataTemplateSelector value)
+        {
+            element.SetValue(DropAdornerMultiItemTemplateSelectorProperty, value);
         }
 
         /// <summary>

--- a/src/GongSolutions.WPF.DragDrop/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.cs
@@ -94,6 +94,28 @@ namespace GongSolutions.Wpf.DragDrop
             return templateSelector;
         }
 
+        internal static DataTemplate TryGetDragAdornerMultiItemTemplate(UIElement source, UIElement sender)
+        {
+            var template = source is not null ? GetDragAdornerMultiItemTemplate(source) : null;
+            if (template is null && sender is not null)
+            {
+                template = GetDragAdornerMultiItemTemplate(sender);
+            }
+
+            return template;
+        }
+
+        internal static DataTemplateSelector TryGetDragAdornerMultiItemTemplateSelector(UIElement source, UIElement sender)
+        {
+            var templateSelector = source is not null ? GetDragAdornerMultiItemTemplateSelector(source) : null;
+            if (templateSelector is null && sender is not null)
+            {
+                templateSelector = GetDragAdornerMultiItemTemplateSelector(sender);
+            }
+
+            return templateSelector;
+        }
+
         internal static ItemsPanelTemplate TryGetDragAdornerItemsPanel(UIElement source, UIElement sender)
         {
             var itemsPanel = source is not null ? GetDragAdornerItemsPanel(source) : null;
@@ -122,6 +144,28 @@ namespace GongSolutions.Wpf.DragDrop
             if (templateSelector is null && sender is not null)
             {
                 templateSelector = GetDropAdornerTemplateSelector(sender);
+            }
+
+            return templateSelector;
+        }
+
+        internal static DataTemplate TryGetDropAdornerMultiItemTemplate(UIElement source, UIElement sender)
+        {
+            var template = source is not null ? GetDropAdornerMultiItemTemplate(source) : null;
+            if (template is null && sender is not null)
+            {
+                template = GetDropAdornerMultiItemTemplate(sender);
+            }
+
+            return template;
+        }
+
+        internal static DataTemplateSelector TryGetDropAdornerMultiItemTemplateSelector(UIElement source, UIElement sender)
+        {
+            var templateSelector = source is not null ? GetDropAdornerMultiItemTemplateSelector(source) : null;
+            if (templateSelector is null && sender is not null)
+            {
+                templateSelector = GetDropAdornerMultiItemTemplateSelector(sender);
             }
 
             return templateSelector;

--- a/src/GongSolutions.WPF.DragDrop/DragDropPreview.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDropPreview.cs
@@ -152,6 +152,11 @@ namespace GongSolutions.Wpf.DragDrop
             }
         }
 
+        private static bool IsMultiSelection(IDragInfo dragInfo)
+        {
+            return dragInfo?.Data is IEnumerable and not string;
+        }
+
         public static bool HasDragDropPreview(IDragInfo dragInfo, UIElement visualTarget, UIElement sender)
         {
             var visualSource = dragInfo?.VisualSource;
@@ -160,9 +165,15 @@ namespace GongSolutions.Wpf.DragDrop
                 return false;
             }
 
+            var isMultiSelection = IsMultiSelection(dragInfo);
+
             // Check for target template or template selector
-            DataTemplate template = DragDrop.TryGetDropAdornerTemplate(visualTarget, sender);
-            DataTemplateSelector templateSelector = DragDrop.TryGetDropAdornerTemplateSelector(visualTarget, sender);
+            DataTemplate template = isMultiSelection
+                ? DragDrop.TryGetDropAdornerMultiItemTemplate(visualTarget, sender) ?? DragDrop.TryGetDropAdornerTemplate(visualTarget, sender)
+                : DragDrop.TryGetDropAdornerTemplate(visualTarget, sender);
+            DataTemplateSelector templateSelector = isMultiSelection
+                ? DragDrop.TryGetDropAdornerMultiItemTemplateSelector(visualTarget, sender) ?? DragDrop.TryGetDropAdornerTemplateSelector(visualTarget, sender)
+                : DragDrop.TryGetDropAdornerTemplateSelector(visualTarget, sender);
 
             if (template is not null)
             {
@@ -172,8 +183,12 @@ namespace GongSolutions.Wpf.DragDrop
             // Check for source template or template selector if there is no target one
             if (template is null && templateSelector is null)
             {
-                template = DragDrop.TryGetDragAdornerTemplate(visualSource, sender);
-                templateSelector = DragDrop.TryGetDragAdornerTemplateSelector(visualSource, sender);
+                template = isMultiSelection
+                    ? DragDrop.TryGetDragAdornerMultiItemTemplate(visualSource, sender) ?? DragDrop.TryGetDragAdornerTemplate(visualSource, sender)
+                    : DragDrop.TryGetDragAdornerTemplate(visualSource, sender);
+                templateSelector = isMultiSelection
+                    ? DragDrop.TryGetDragAdornerMultiItemTemplateSelector(visualSource, sender) ?? DragDrop.TryGetDragAdornerTemplateSelector(visualSource, sender)
+                    : DragDrop.TryGetDragAdornerTemplateSelector(visualSource, sender);
 
                 var useDefaultDragAdorner = template is null && templateSelector is null && DragDrop.GetUseDefaultDragAdorner(visualSource);
                 if (useDefaultDragAdorner)
@@ -198,9 +213,15 @@ namespace GongSolutions.Wpf.DragDrop
                 return;
             }
 
+            var isMultiSelection = IsMultiSelection(dragInfo);
+
             // Get target template or template selector
-            DataTemplate template = DragDrop.TryGetDropAdornerTemplate(visualTarget, sender);
-            DataTemplateSelector templateSelector = DragDrop.TryGetDropAdornerTemplateSelector(visualTarget, sender);
+            DataTemplate template = isMultiSelection
+                ? DragDrop.TryGetDropAdornerMultiItemTemplate(visualTarget, sender) ?? DragDrop.TryGetDropAdornerTemplate(visualTarget, sender)
+                : DragDrop.TryGetDropAdornerTemplate(visualTarget, sender);
+            DataTemplateSelector templateSelector = isMultiSelection
+                ? DragDrop.TryGetDropAdornerMultiItemTemplateSelector(visualTarget, sender) ?? DragDrop.TryGetDropAdornerTemplateSelector(visualTarget, sender)
+                : DragDrop.TryGetDropAdornerTemplateSelector(visualTarget, sender);
             ItemsPanelTemplate itemsPanel = DragDrop.TryGetDropAdornerItemsPanel(visualTarget, sender);
 
             if (template is not null)
@@ -211,8 +232,12 @@ namespace GongSolutions.Wpf.DragDrop
             // Get source template or template selector if there is no target one
             if (template is null && templateSelector is null)
             {
-                template = DragDrop.TryGetDragAdornerTemplate(visualSource, sender);
-                templateSelector = DragDrop.TryGetDragAdornerTemplateSelector(visualSource, sender);
+                template = isMultiSelection
+                    ? DragDrop.TryGetDragAdornerMultiItemTemplate(visualSource, sender) ?? DragDrop.TryGetDragAdornerTemplate(visualSource, sender)
+                    : DragDrop.TryGetDragAdornerTemplate(visualSource, sender);
+                templateSelector = isMultiSelection
+                    ? DragDrop.TryGetDragAdornerMultiItemTemplateSelector(visualSource, sender) ?? DragDrop.TryGetDragAdornerTemplateSelector(visualSource, sender)
+                    : DragDrop.TryGetDragAdornerTemplateSelector(visualSource, sender);
                 itemsPanel = DragDrop.TryGetDragAdornerItemsPanel(visualTarget, sender);
 
                 this.UseDefaultDragAdorner = template is null && templateSelector is null && DragDrop.GetUseDefaultDragAdorner(visualSource);
@@ -233,7 +258,7 @@ namespace GongSolutions.Wpf.DragDrop
             this.SetCurrentValue(ItemsPanelProperty, itemsPanel);
         }
 
-        public UIElement CreatePreviewPresenter(IDragInfo dragInfo, UIElement visualTarget, UIElement sender)
+        private UIElement CreatePreviewPresenter(IDragInfo dragInfo, UIElement visualTarget, UIElement sender)
         {
             var visualSource = dragInfo?.VisualSource;
             if (visualSource is null)


### PR DESCRIPTION
## What changed?

Add DragAdorner and DropAdorner DataTemplate/Selector for multiple item selection

`dd:DragDrop.DragAdornerMultiItemTemplate="{StaticResource MultiItemTemplate}"`
`dd:DragDrop.DropAdornerMultiItemTemplate="{StaticResource MultiItemTemplate}"`

Sample

```xaml
<ListBox x:Name="SampleListBox"
         dd:DragDrop.IsDragSource="True"
         dd:DragDrop.IsDropTarget="True"
         dd:DragDrop.DragAdornerMultiItemTemplate="{StaticResource MultiItemTemplate}"
         dd:DragDrop.DropAdornerMultiItemTemplate="{StaticResource MultiItemTemplate}"
         ItemsSource="{Binding SampleDataCollection}" />
```

With this properties it's possible to set different template for multiple selected items. If no template is set then the single templates are used.

_Closed issues._

Closes #228 
