### PR TITLE
Enable dragging of ToggleButton controls

### DIFF
--- a/src/Showcase/Models/ItemModel.cs
+++ b/src/Showcase/Models/ItemModel.cs
@@ -13,6 +13,7 @@ namespace Showcase.WPF.DragDrop.Models
         private double _bindableDoubleValue;
         private string _selectedSubItem;
         private bool _isChecked;
+        private bool _isExpanded;
 
         public ItemModel()
         {
@@ -54,6 +55,17 @@ namespace Showcase.WPF.DragDrop.Models
             {
                 if (value == this._isChecked) return;
                 this._isChecked = value;
+                this.OnPropertyChanged();
+            }
+        }
+
+        public bool IsExpanded
+        {
+            get => this._isExpanded;
+            set
+            {
+                if (value == this._isExpanded) return;
+                this._isExpanded = value;
                 this.OnPropertyChanged();
             }
         }

--- a/src/Showcase/Views/Issues.xaml
+++ b/src/Showcase/Views/Issues.xaml
@@ -937,16 +937,18 @@
                                           SelectionMode="Extended">
                                     <ListView.ItemTemplate>
                                         <DataTemplate>
-                                            <StackPanel Orientation="Horizontal">
-                                                <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="2" />
-                                                <TextBlock Text="{Binding Caption}" Margin="2" />
-                                                <Menu Margin="2">
-                                                    <MenuItem Header="Menu">
-                                                        <MenuItem Header="Some Menu Item"></MenuItem>
-                                                        <MenuItem Header="Some Other Menu Item"></MenuItem>
-                                                    </MenuItem>
-                                                </Menu>
-                                            </StackPanel>
+                                            <Expander IsExpanded="{Binding IsExpanded, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Header="{Binding Caption}">
+                                                <StackPanel Orientation="Horizontal">
+                                                    <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="2" />
+                                                    <TextBlock Text="{Binding Caption}" Margin="2" />
+                                                    <Menu Margin="2">
+                                                        <MenuItem Header="Menu">
+                                                            <MenuItem Header="Some Menu Item"></MenuItem>
+                                                            <MenuItem Header="Some Other Menu Item"></MenuItem>
+                                                        </MenuItem>
+                                                    </Menu>
+                                                </StackPanel>
+                                            </Expander>
                                         </DataTemplate>
                                     </ListView.ItemTemplate>
                                 </ListView>


### PR DESCRIPTION
## What changed?

_Describe the changes you have made to improve this project._

- change sample from #342
- enable dragging ToggleButton controls

With changes for #342 the dragging of ToggleButton controls was gone. To re-enable this it's necessary to remove the test in GetHitTestResult and don't handle the mouse inputs for it (down and up). So after that it's possible to toggle the state or drag the control.

_Closed issues._

Closes #420 
