### PR TITLE
Enable custom IDragInfo & IDropInfo implementations

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
@@ -1614,7 +1614,7 @@ namespace GongSolutions.Wpf.DragDrop
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="ScrollViewer"/> that will be used as <see cref="DropInfo.TargetScrollViewer"/>.
+        /// Gets or sets the <see cref="ScrollViewer"/> that will be used as <see cref="IDropInfo.TargetScrollViewer"/>.
         /// </summary>
         public static readonly DependencyProperty DropTargetScrollViewerProperty
             = DependencyProperty.RegisterAttached("DropTargetScrollViewer",
@@ -1624,7 +1624,7 @@ namespace GongSolutions.Wpf.DragDrop
 
         /// <summary>Helper for getting <see cref="DropTargetScrollViewerProperty"/> from <paramref name="element"/>.</summary>
         /// <param name="element"><see cref="DependencyObject"/> to read <see cref="DropTargetScrollViewerProperty"/> from.</param>
-        /// <remarks>Gets the <see cref="ScrollViewer"/> that will be used as <see cref="DropInfo.TargetScrollViewer"/>.</remarks>
+        /// <remarks>Gets the <see cref="ScrollViewer"/> that will be used as <see cref="IDropInfo.TargetScrollViewer"/>.</remarks>
         /// <returns>DropTargetScrollViewer property value.</returns>
         [AttachedPropertyBrowsableForType(typeof(UIElement))]
         public static ScrollViewer GetDropTargetScrollViewer(DependencyObject element)
@@ -1635,7 +1635,7 @@ namespace GongSolutions.Wpf.DragDrop
         /// <summary>Helper for setting <see cref="DropTargetScrollViewerProperty"/> on <paramref name="element"/>.</summary>
         /// <param name="element"><see cref="DependencyObject"/> to set <see cref="DropTargetScrollViewerProperty"/> on.</param>
         /// <param name="value">DropTargetScrollViewer property value.</param>
-        /// <remarks>Sets the <see cref="ScrollViewer"/> that will be used as <see cref="DropInfo.TargetScrollViewer"/>.</remarks>
+        /// <remarks>Sets the <see cref="ScrollViewer"/> that will be used as <see cref="IDropInfo.TargetScrollViewer"/>.</remarks>
         [AttachedPropertyBrowsableForType(typeof(UIElement))]
         public static void SetDropTargetScrollViewer(DependencyObject element, ScrollViewer value)
         {

--- a/src/GongSolutions.WPF.DragDrop/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.cs
@@ -467,7 +467,7 @@ namespace GongSolutions.Wpf.DragDrop
             DragSourceDown(sender, dragInfo, e, elementPosition);
         }
 
-        private static void DragSourceDown(object sender, DragInfo dragInfo, InputEventArgs e, Point elementPosition)
+        private static void DragSourceDown(object sender, IDragInfo dragInfo, InputEventArgs e, Point elementPosition)
         {
             if (dragInfo.VisualSource is ItemsControl control && control.CanSelectMultipleItems())
             {
@@ -619,7 +619,7 @@ namespace GongSolutions.Wpf.DragDrop
                     && (Math.Abs(position.X - dragStart.X) > DragDrop.GetMinimumHorizontalDragDistance(dragInfo.VisualSource) ||
                         Math.Abs(position.Y - dragStart.Y) > DragDrop.GetMinimumVerticalDragDistance(dragInfo.VisualSource)))
                 {
-                    dragInfo.RefreshSelectedItems(sender);
+                    dragInfo.RefreshSourceItems(sender);
 
                     var dragHandler = TryGetDragHandler(dragInfo, sender as UIElement);
                     if (dragHandler.CanStartDrag(dragInfo))
@@ -1040,7 +1040,7 @@ namespace GongSolutions.Wpf.DragDrop
             }
         }
 
-        private static DragInfo _dragInfo;
+        private static IDragInfo _dragInfo;
         private static bool _dragInProgress;
         private static object _clickSupressItem;
 

--- a/src/GongSolutions.WPF.DragDrop/DragInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragInfo.cs
@@ -197,7 +197,8 @@ namespace GongSolutions.Wpf.DragDrop
             this.SourceItems ??= Enumerable.Empty<object>();
         }
 
-        internal void RefreshSelectedItems(object sender)
+        /// <inheritdoc />
+        public virtual void RefreshSourceItems(object sender)
         {
             if (sender is not ItemsControl itemsControl)
             {

--- a/src/GongSolutions.WPF.DragDrop/DropInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop/DropInfo.cs
@@ -96,14 +96,10 @@ namespace GongSolutions.Wpf.DragDrop
         /// <inheritdoc />
         public CollectionViewGroup TargetGroup { get; protected set; }
 
-        /// <summary>
-        /// Gets the ScrollViewer control for the visual target.
-        /// </summary>
+        /// <inheritdoc />
         public ScrollViewer TargetScrollViewer { get; protected set; }
 
-        /// <summary>
-        /// Gets or Sets the ScrollingMode for the drop action.
-        /// </summary>
+        /// <inheritdoc />
         public ScrollingMode TargetScrollingMode { get; set; }
 
         /// <inheritdoc />

--- a/src/GongSolutions.WPF.DragDrop/DropTargetAdorner.cs
+++ b/src/GongSolutions.WPF.DragDrop/DropTargetAdorner.cs
@@ -59,7 +59,7 @@ namespace GongSolutions.Wpf.DragDrop
                 throw new InvalidOperationException("The requested adorner class does not derive from DropTargetAdorner.");
             }
 
-            return type.GetConstructor(new[] { typeof(UIElement), typeof(DropInfo) })?.Invoke(new object[] { adornedElement, dropInfo }) as DropTargetAdorner;
+            return type.GetConstructor(new[] { typeof(UIElement), typeof(IDropInfo) })?.Invoke(new object[] { adornedElement, dropInfo }) as DropTargetAdorner;
         }
     }
 }

--- a/src/GongSolutions.WPF.DragDrop/DropTargetAdorner.cs
+++ b/src/GongSolutions.WPF.DragDrop/DropTargetAdorner.cs
@@ -59,7 +59,13 @@ namespace GongSolutions.Wpf.DragDrop
                 throw new InvalidOperationException("The requested adorner class does not derive from DropTargetAdorner.");
             }
 
-            return type.GetConstructor(new[] { typeof(UIElement), typeof(IDropInfo) })?.Invoke(new object[] { adornedElement, dropInfo }) as DropTargetAdorner;
+            var ctor = type.GetConstructor(new[] { typeof(UIElement), typeof(IDropInfo) });
+            if (ctor is null && dropInfo is DropInfo)
+            {
+                ctor = type.GetConstructor(new[] { typeof(UIElement), typeof(DropInfo) });
+            }
+
+            return ctor?.Invoke(new object[] { adornedElement, dropInfo }) as DropTargetAdorner;
         }
     }
 }

--- a/src/GongSolutions.WPF.DragDrop/DropTargetInsertionAdorner.cs
+++ b/src/GongSolutions.WPF.DragDrop/DropTargetInsertionAdorner.cs
@@ -9,7 +9,7 @@ namespace GongSolutions.Wpf.DragDrop
 {
     public class DropTargetInsertionAdorner : DropTargetAdorner
     {
-        public DropTargetInsertionAdorner(UIElement adornedElement, DropInfo dropInfo)
+        public DropTargetInsertionAdorner(UIElement adornedElement, IDropInfo dropInfo)
             : base(adornedElement, dropInfo)
         {
         }

--- a/src/GongSolutions.WPF.DragDrop/IDragInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop/IDragInfo.cs
@@ -119,5 +119,11 @@ namespace GongSolutions.Wpf.DragDrop
         /// Gets the drag drop copy key state indicating the effect of the drag drop operation.
         /// </summary>
         DragDropKeyStates DragDropCopyKeyState { get; }
+
+        /// <summary>
+        /// Refreshes the <see cref="SourceItems" /> property.
+        /// </summary>
+        /// <param name="sender">The drag source control.</param>
+        void RefreshSourceItems(object sender);
     }
 }

--- a/src/GongSolutions.WPF.DragDrop/IDragInfoBuilder.cs
+++ b/src/GongSolutions.WPF.DragDrop/IDragInfoBuilder.cs
@@ -19,6 +19,6 @@ namespace GongSolutions.Wpf.DragDrop
         /// <param name="mouseButton">The mouse button which was used for the drag operation.</param>
         /// <param name="getPosition">A function of the input event which is used to get drag position points.</param>
         [CanBeNull]
-        DragInfo CreateDragInfo(object sender, object originalSource, MouseButton mouseButton, Func<IInputElement, Point> getPosition);
+        IDragInfo CreateDragInfo(object sender, object originalSource, MouseButton mouseButton, Func<IInputElement, Point> getPosition);
     }
 }

--- a/src/GongSolutions.WPF.DragDrop/IDragSource.cs
+++ b/src/GongSolutions.WPF.DragDrop/IDragSource.cs
@@ -13,7 +13,7 @@ namespace GongSolutions.Wpf.DragDrop
         /// </summary>
         /// <param name="dragInfo">Object which contains several drag information.</param>
         /// <remarks>
-        /// To allow a drag to be started, the <see cref="DragInfo.Effects" /> property on <paramref name="dragInfo" />
+        /// To allow a drag to be started, the <see cref="IDragInfo.Effects" /> property on <paramref name="dragInfo" />
         /// should be set to a value other than <see cref="DragDropEffects.None" />.
         /// </remarks>
         void StartDrag(IDragInfo dragInfo);

--- a/src/GongSolutions.WPF.DragDrop/IDropInfoBuilder.cs
+++ b/src/GongSolutions.WPF.DragDrop/IDropInfoBuilder.cs
@@ -17,6 +17,6 @@ namespace GongSolutions.Wpf.DragDrop
         /// <param name="dragInfo">Information about the drag source, if the drag came from within the framework.</param>
         /// <param name="eventType">The type of the underlying event (tunneled or bubbled).</param>
         [CanBeNull]
-        IDropInfo CreateDropInfo(object sender, DragEventArgs e, [CanBeNull] DragInfo dragInfo, EventType eventType);
+        IDropInfo CreateDropInfo(object sender, DragEventArgs e, [CanBeNull] IDragInfo dragInfo, EventType eventType);
     }
 }

--- a/src/GongSolutions.WPF.DragDrop/IDropTarget.cs
+++ b/src/GongSolutions.WPF.DragDrop/IDropTarget.cs
@@ -38,9 +38,9 @@ namespace GongSolutions.Wpf.DragDrop
         /// </summary>
         /// <param name="dropInfo">Object which contains several drop information.</param>
         /// <remarks>
-        /// To allow a drop at the current drag position, the <see cref="DropInfo.Effects"/> property on
+        /// To allow a drop at the current drag position, the <see cref="IDropInfo.Effects"/> property on
         /// <paramref name="dropInfo"/> should be set to a value other than <see cref="DragDropEffects.None"/>
-        /// and <see cref="DropInfo.Data"/> should be set to a non-null value.
+        /// and <see cref="IDropInfo.Data"/> should be set to a non-null value.
         /// </remarks>
         void DragOver(IDropInfo dropInfo);
 

--- a/src/Showcase/Models/TextBoxCustomDropHandler.cs
+++ b/src/Showcase/Models/TextBoxCustomDropHandler.cs
@@ -69,7 +69,7 @@ namespace Showcase.WPF.DragDrop.Models
         private readonly Pen _pen;
         private readonly Brush _brush;
 
-        public DropTargetHighlightAdorner(UIElement adornedElement, DropInfo dropInfo)
+        public DropTargetHighlightAdorner(UIElement adornedElement, IDropInfo dropInfo)
             : base(adornedElement, dropInfo)
         {
             this._pen = new Pen(Brushes.Tomato, 2);


### PR DESCRIPTION
## What changed?

The new `IDragInfoBuilder` and `IDropInfoBuilder` are great, but there are still some scenarios where it's not possible to override default behavior.

This PR further embraces the `IDragInfo` and `IDropInfo` interfaces, enabling more custom implementations.

I needed this when implementing drag-n-drop for a custom multi selection tree view.

### Breaking changes
- `IDragInfoBuilder.CreateDragInfo` now returns `IDragInfo` instead of `DragInfo`
- `IDropInfoBuilder.CreateDropInfo` now takes an `IDragInfo` instead of `DragInfo`
- `RefreshSourceItems` method added to `IDragInfo`. This is not really a breaking change, as up until this PR, it wasn't possible to use a fully custom implementation of `IDragInfo` and any existing implementations will be inheriting from `DragInfo`.