### PR TITLE
Cancel drag when both mouse buttons are pressed

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.cs
@@ -675,7 +675,7 @@ namespace GongSolutions.Wpf.DragDrop
 
         private static void DragSourceOnQueryContinueDrag(object sender, QueryContinueDragEventArgs e)
         {
-            if (e.Action == DragAction.Cancel || e.EscapePressed || (e.KeyStates.HasFlag(DragDropKeyStates.LeftMouseButton) == false && e.KeyStates.HasFlag(DragDropKeyStates.RightMouseButton) == false))
+            if (e.Action == DragAction.Cancel || e.EscapePressed || (e.KeyStates.HasFlag(DragDropKeyStates.LeftMouseButton) == e.KeyStates.HasFlag(DragDropKeyStates.RightMouseButton)))
             {
                 DragDropPreview = null;
                 DragDropEffectPreview = null;


### PR DESCRIPTION
## What changed?

This fixes the drag adorner getting stuck when the user cancels a drag by also pressing the other mouse button.

Demonstration of the issue:
![StuckDragAdorner](https://user-images.githubusercontent.com/1404846/151583750-f0dcb228-bb6b-4b56-937a-c08180b73400.gif)

_Closed issues._
Fixes #425 