### PR TITLE
Add own cloneable interface for easier handling

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/DefaultDropHandler.cs
+++ b/src/GongSolutions.WPF.DragDrop/DefaultDropHandler.cs
@@ -297,9 +297,9 @@ namespace GongSolutions.Wpf.DragDrop
                     var obj2Insert = o;
                     if (cloneData)
                     {
-                        if (o is IDragItemCloneable cloneableItem)
+                        if (o is ICloneableDragItem cloneableItem)
                         {
-                            obj2Insert = cloneableItem.CloneDragItem(dropInfo);
+                            obj2Insert = cloneableItem.CloneItem(dropInfo);
                         }
                         else if (o is ICloneable cloneable)
                         {

--- a/src/GongSolutions.WPF.DragDrop/DefaultDropHandler.cs
+++ b/src/GongSolutions.WPF.DragDrop/DefaultDropHandler.cs
@@ -297,7 +297,11 @@ namespace GongSolutions.Wpf.DragDrop
                     var obj2Insert = o;
                     if (cloneData)
                     {
-                        if (o is ICloneable cloneable)
+                        if (o is IDragItemCloneable cloneableItem)
+                        {
+                            obj2Insert = cloneableItem.CloneDragItem(dropInfo);
+                        }
+                        else if (o is ICloneable cloneable)
                         {
                             obj2Insert = cloneable.Clone();
                         }

--- a/src/GongSolutions.WPF.DragDrop/DefaultDropHandler.cs
+++ b/src/GongSolutions.WPF.DragDrop/DefaultDropHandler.cs
@@ -326,6 +326,11 @@ namespace GongSolutions.Wpf.DragDrop
                     {
                         destinationList.Insert(insertIndex++, obj2Insert);
                     }
+
+                    if (obj2Insert is IDragItemSource dragItemSource)
+                    {
+                        dragItemSource.ItemDropped(dropInfo);
+                    }
                 }
 
                 SelectDroppedItems(dropInfo, objects2Insert);

--- a/src/GongSolutions.WPF.DragDrop/ICloneableDragItem.cs
+++ b/src/GongSolutions.WPF.DragDrop/ICloneableDragItem.cs
@@ -3,13 +3,13 @@
     /// <summary>
     /// Supports cloning like the ICloneable interface, which creates a new instance of a class with the same value as an existing instance.
     /// </summary>
-    public interface IDragItemCloneable
+    public interface ICloneableDragItem
     {
         /// <summary>
         /// Creates a new object that is a copy of the current instance.
         /// </summary>
         /// <param name="dropInfo">Object which contains several drop information.</param>
         /// <returns>A new object that is a copy of this instance.</returns>
-        object CloneDragItem(IDropInfo dropInfo);
+        object CloneItem(IDropInfo dropInfo);
     }
 }

--- a/src/GongSolutions.WPF.DragDrop/IDragItemCloneable.cs
+++ b/src/GongSolutions.WPF.DragDrop/IDragItemCloneable.cs
@@ -1,5 +1,8 @@
 ﻿namespace GongSolutions.Wpf.DragDrop
 {
+    /// <summary>
+    /// Supports cloning like the ICloneable interface, which creates a new instance of a class with the same value as an existing instance.
+    /// </summary>
     public interface IDragItemCloneable
     {
         /// <summary>

--- a/src/GongSolutions.WPF.DragDrop/IDragItemCloneable.cs
+++ b/src/GongSolutions.WPF.DragDrop/IDragItemCloneable.cs
@@ -1,0 +1,12 @@
+﻿namespace GongSolutions.Wpf.DragDrop
+{
+    public interface IDragItemCloneable
+    {
+        /// <summary>
+        /// Creates a new object that is a copy of the current instance.
+        /// </summary>
+        /// <param name="dropInfo">Object which contains several drop information.</param>
+        /// <returns>A new object that is a copy of this instance.</returns>
+        object CloneDragItem(IDropInfo dropInfo);
+    }
+}

--- a/src/GongSolutions.WPF.DragDrop/IDragItemSource.cs
+++ b/src/GongSolutions.WPF.DragDrop/IDragItemSource.cs
@@ -1,0 +1,14 @@
+﻿namespace GongSolutions.Wpf.DragDrop
+{
+    /// <summary>
+    /// Supports methods for models which can be dropped.
+    /// </summary>
+    public interface IDragItemSource
+    {
+        /// <summary>
+        /// Indicates that the item is dropped on the destination list.
+        /// </summary>
+        /// <param name="dropInfo">Object which contains several drop information.</param>
+        void ItemDropped(IDropInfo dropInfo);
+    }
+}


### PR DESCRIPTION
## What changed?

_Describe the changes you have made to improve this project._

Add own cloneable interface for easier handling:

```csharp
/// <summary>
/// Supports cloning like the ICloneable interface, which creates a new instance of a class with the same value as an existing instance.
/// </summary>
public interface ICloneableDragItem
{
    /// <summary>
    /// Creates a new object that is a copy of the current instance.
    /// </summary>
    /// <param name="dropInfo">Object which contains several drop information.</param>
    /// <returns>A new object that is a copy of this instance.</returns>
    object CloneItem(IDropInfo dropInfo);
}
```

Add also a new interface for easier handling after item was dropped.

```csharp
/// <summary>
/// Supports methods for models which can be dropped.
/// </summary>
public interface IDragItemSource
{
    /// <summary>
    /// Indicates that the item is dropped on the destination list.
    /// </summary>
    /// <param name="dropInfo">Object which contains several drop information.</param>
    void ItemDropped(IDropInfo dropInfo);
}
```

_Closed issues._

Closes #435 
