### PR TITLE
Check subclass of ObservableCollection<>

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/Utilities/TypeUtilities.cs
+++ b/src/GongSolutions.WPF.DragDrop/Utilities/TypeUtilities.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Collections;
 using System.Collections.ObjectModel;
+using JetBrains.Annotations;
 
 namespace GongSolutions.Wpf.DragDrop.Utilities
 {
@@ -86,11 +87,24 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
         /// </summary>
         /// <param name="collection">The collection to test.</param>
         /// <returns>True if the collection is a ObservableCollection&lt;&gt;</returns>
-        public static bool IsObservableCollection(this IList collection)
+        public static bool IsObservableCollection([CanBeNull] this IList collection)
         {
-            return collection != null
-                   && collection.GetType().IsGenericType
-                   && collection.GetType().GetGenericTypeDefinition() == typeof(ObservableCollection<>);
+            return collection != null && IsObservableCollectionType(collection.GetType());
+        }
+
+        private static bool IsObservableCollectionType([CanBeNull] Type type)
+        {
+            if (type is null || !typeof(IList).IsAssignableFrom(type))
+            {
+                return false;
+            }
+
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ObservableCollection<>))
+            {
+                return true;
+            }
+
+            return IsObservableCollectionType(type.BaseType);
         }
 
         /// <summary>

--- a/src/Showcase/Models/ItemModel.cs
+++ b/src/Showcase/Models/ItemModel.cs
@@ -158,6 +158,10 @@ namespace Showcase.WPF.DragDrop.Models
         }
     }
 
+    public class ItemModelObservableCollection : ObservableCollection<ItemModel>
+    {
+    }
+
     [Serializable]
     public class SerializableItemModel
     {

--- a/src/Showcase/Models/SampleData.cs
+++ b/src/Showcase/Models/SampleData.cs
@@ -17,6 +17,7 @@ namespace Showcase.WPF.DragDrop.Models
                 this.ClonableCollection1.Add(new ClonableItemModel(n + 1));
                 this.DataGridCollection1.Add(new DataGridRowModel());
             }
+
             for (var n = 0; n < 10; ++n)
             {
                 this.Collection4.Add(new ItemModel() { Caption = $"Model {n + 1}" });
@@ -40,6 +41,7 @@ namespace Showcase.WPF.DragDrop.Models
                 {
                     root.Children.Add(new TreeNode($"Item {i + 10 * r}"));
                 }
+
                 this.TreeCollection1.Add(root);
                 if (r == 2)
                 {
@@ -51,6 +53,7 @@ namespace Showcase.WPF.DragDrop.Models
             {
                 this.TabItemCollection1.Add(new TabItemModel(i + 1));
             }
+
             this.TabItemCollection2.Add(new TabItemModel(1));
         }
 
@@ -62,7 +65,7 @@ namespace Showcase.WPF.DragDrop.Models
 
         public SerializableDropHandler SerializableDropHandler { get; set; } = new SerializableDropHandler();
 
-        public ObservableCollection<ItemModel> Collection1 { get; set; } = new ObservableCollection<ItemModel>();
+        public ItemModelObservableCollection Collection1 { get; set; } = new ItemModelObservableCollection();
 
         public ObservableCollection<ItemModel> Collection2 { get; set; } = new ObservableCollection<ItemModel>();
 


### PR DESCRIPTION
## What changed?

Currently, If `collection` is subclass of `ObservableCollection<>`, `IsObservableCollection(collection)` returns false.
But I hope the method call returns true.

Sample
```cs
void Check()
{
    var result = new StringObservableCollection().IsObservableCollection();
   // I hope result is true, but it's false.
}
class StringObservableCollection : ObservableCollection<string> { }
```