### PR TITLE
Add logic to disallow child items in tree views

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/DropInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop/DropInfo.cs
@@ -13,10 +13,10 @@ namespace GongSolutions.Wpf.DragDrop
     /// <summary>
     /// Holds information about a the target of a drag drop operation.
     /// </summary>
-    /// 
+    ///
     /// <remarks>
-    /// The <see cref="DropInfo"/> class holds all of the framework's information about the current 
-    /// target of a drag. It is used by <see cref="IDropTarget.DragOver"/> method to determine whether 
+    /// The <see cref="DropInfo"/> class holds all of the framework's information about the current
+    /// target of a drag. It is used by <see cref="IDropTarget.DragOver"/> method to determine whether
     /// the current drop target is valid, and by <see cref="IDropTarget.Drop"/> to perform the drop.
     /// </remarks>
     public class DropInfo : IDropInfo
@@ -154,21 +154,16 @@ namespace GongSolutions.Wpf.DragDrop
         /// <inheritdoc />
         public EventType EventType { get; }
 
-        /// <summary>
-        /// Indicates if the drop target can accept the dragged data as a child item (applies to tree view items).
-        /// </summary>
-        /// <remarks>
-        /// Changing this value will update other properties.
-        /// </remarks>
+        /// <inheritdoc />
         public bool AcceptChildItem
         {
             get => this.acceptChildItem.GetValueOrDefault();
             set
             {
-                if (value != this.acceptChildItem)
+                if (value != this.acceptChildItem.GetValueOrDefault())
                 {
                     this.acceptChildItem = value;
-                    Update();
+                    this.Update();
                 }
             }
         }
@@ -222,17 +217,14 @@ namespace GongSolutions.Wpf.DragDrop
             // visual target can be null, so give us a point...
             this.DropPosition = this.VisualTarget != null ? e.GetPosition(this.VisualTarget) : new Point();
 
-            Update();
+            this.Update();
         }
 
         private void Update()
         {
-            if (this.VisualTarget is TabControl)
+            if (this.VisualTarget is TabControl && !HitTestUtilities.HitTest4Type<TabPanel>(this.VisualTarget, this.DropPosition))
             {
-                if (!HitTestUtilities.HitTest4Type<TabPanel>(this.VisualTarget, this.DropPosition))
-                {
-                    return;
-                }
+                return;
             }
 
             if (this.VisualTarget is ItemsControl itemsControl)

--- a/src/GongSolutions.WPF.DragDrop/IDropInfo.cs
+++ b/src/GongSolutions.WPF.DragDrop/IDropInfo.cs
@@ -154,5 +154,13 @@ namespace GongSolutions.Wpf.DragDrop
         /// Gets the current mode of the underlying routed event.
         /// </summary>
         EventType EventType { get; }
+
+        /// <summary>
+        /// Indicates if the drop target can accept the dragged data as a child item (applies to tree view items).
+        /// </summary>
+        /// <remarks>
+        /// Changing this value will update other properties.
+        /// </remarks>
+        bool AcceptChildItem { get; set; }
     }
 }

--- a/src/Showcase/Models/FilesDropHandler.cs
+++ b/src/Showcase/Models/FilesDropHandler.cs
@@ -1,0 +1,15 @@
+﻿namespace Showcase.WPF.DragDrop.Models;
+
+using GongSolutions.Wpf.DragDrop;
+using MahApps.Metro.IconPacks;
+
+public class FilesDropHandler : DefaultDropHandler
+{
+    public override void DragOver(IDropInfo dropInfo)
+    {
+        if (dropInfo is DropInfo { TargetItem: not TreeNode { Icon: PackIconMaterialKind.Folder } } typedDropInfo)
+            typedDropInfo.AcceptChildItem = false;
+
+        base.DragOver(dropInfo);
+    }
+}

--- a/src/Showcase/Models/SampleData.cs
+++ b/src/Showcase/Models/SampleData.cs
@@ -5,6 +5,8 @@ using GongSolutions.Wpf.DragDrop;
 
 namespace Showcase.WPF.DragDrop.Models
 {
+    using MahApps.Metro.IconPacks;
+
     public class SampleData
     {
         public SampleData()
@@ -37,15 +39,19 @@ namespace Showcase.WPF.DragDrop.Models
             for (int r = 1; r <= 6; r++)
             {
                 var root = new TreeNode($"Root {r}");
+                var folder = new TreeNode($"Folder {r}") { Icon = PackIconMaterialKind.Folder };
                 for (var i = 0; i < ((r % 2) == 0 ? 8 : 3); ++i)
                 {
                     root.Children.Add(new TreeNode($"Item {i + 10 * r}"));
+                    folder.Children.Add(new TreeNode($"File {i + 10 * r}") { Icon = PackIconMaterialKind.File });
                 }
 
                 this.TreeCollection1.Add(root);
+                this.TreeCollectionFiles.Add(folder);
                 if (r == 2)
                 {
                     root.IsExpanded = true;
+                    folder.IsExpanded = true;
                 }
             }
 
@@ -84,6 +90,10 @@ namespace Showcase.WPF.DragDrop.Models
         public ObservableCollection<TreeNode> TreeCollection1 { get; set; } = new ObservableCollection<TreeNode>();
 
         public ObservableCollection<TreeNode> TreeCollection2 { get; set; } = new ObservableCollection<TreeNode>();
+
+        public ObservableCollection<TreeNode> TreeCollectionFiles { get; set; } = new ObservableCollection<TreeNode>();
+
+        public FilesDropHandler FilesDropHandler { get; set; } = new FilesDropHandler();
 
         public GroupedDropHandler GroupedDropHandler { get; set; } = new GroupedDropHandler();
 

--- a/src/Showcase/Models/TreeNode.cs
+++ b/src/Showcase/Models/TreeNode.cs
@@ -3,11 +3,13 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
+using MahApps.Metro.IconPacks;
 
 namespace Showcase.WPF.DragDrop.Models
 {
     public class TreeNode : INotifyPropertyChanged, ICloneable
     {
+        private PackIconMaterialKind _icon;
         private string _caption;
         private ObservableCollection<TreeNode> _children;
         private bool _isCloned;
@@ -17,6 +19,17 @@ namespace Showcase.WPF.DragDrop.Models
         {
             this.Caption = caption;
             this.Children = new ObservableCollection<TreeNode>();
+        }
+
+        public PackIconMaterialKind Icon
+        {
+            get => this._icon;
+            set
+            {
+                if (value == this._icon) return;
+                this._icon = value;
+                this.OnPropertyChanged();
+            }
         }
 
         public string Caption

--- a/src/Showcase/Views/TreeViewSamples.xaml
+++ b/src/Showcase/Views/TreeViewSamples.xaml
@@ -6,6 +6,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:viewModels="clr-namespace:Showcase.WPF.DragDrop.ViewModels"
              xmlns:views="clr-namespace:Showcase.WPF.DragDrop.Views"
+             xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
              d:DataContext="{d:DesignInstance viewModels:MainViewModel}"
              d:DesignHeight="400"
              d:DesignWidth="600"
@@ -144,6 +145,44 @@
                             </Grid>
                         </StackPanel>
                     </ScrollViewer>
+                </DockPanel>
+            </TabItem>
+
+            <TabItem Header="Files">
+                <TabItem.Resources>
+                    <Style x:Key="BoundTreeViewItemStyle" TargetType="{x:Type TreeViewItem}">
+                        <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}" />
+                        <Setter Property="Padding" Value="2" />
+                    </Style>
+                </TabItem.Resources>
+                <DockPanel>
+                    <TextBlock DockPanel.Dock="Top"
+                               Style="{StaticResource SampleHeaderTextBlockStyle}"
+                               Text="Files and Folders" />
+                    <TextBlock DockPanel.Dock="Top"
+                               Style="{StaticResource DefaultTextBlockStyle}"
+                               Text="Demonstrates custom logic which defines if a TreeView item can receive child items (folders) or not (files)." />
+                    <TreeView dd:DragDrop.IsDragSource="True"
+                              dd:DragDrop.IsDropTarget="True"
+                              dd:DragDrop.DropHandler="{Binding Data.FilesDropHandler}"
+                              dd:DragDrop.UseDefaultDragAdorner="True"
+                              dd:DragDrop.UseDefaultEffectDataTemplate="True"
+                              dd:DragDrop.SelectDroppedItems="True"
+                              Height="NaN"
+                              ItemContainerStyle="{StaticResource BoundTreeViewItemStyle}"
+                              ItemsSource="{Binding Data.TreeCollectionFiles}">
+                        <TreeView.ItemTemplate>
+                            <HierarchicalDataTemplate ItemsSource="{Binding Children}">
+                                <StackPanel Orientation="Horizontal">
+                                    <iconPacks:PackIconMaterial Focusable="False"
+                                                                Foreground="Gray"
+                                                                Kind="{Binding Icon}" />
+                                    <TextBlock Margin="4,2,2,2"
+                                               Text="{Binding Caption}" />
+                                </StackPanel>
+                            </HierarchicalDataTemplate>
+                        </TreeView.ItemTemplate>
+                    </TreeView>
                 </DockPanel>
             </TabItem>
         </TabControl>


### PR DESCRIPTION
## What changed?

This fixes #344, in a different way than #345.

I wanted to fix this issue, but I felt it's the role of the drop handler to decide whether an item should accept children or not (instead of handling this through a dependency property of the item). This also enables providing custom logic.

Problem is, at that point the `IDropInfo` is already populated with the "wrong" `TargetCollection`/`InsertIndex` info because everything is decided upfront in the constructor of `DropInfo`.

I didn't want to introduce a breaking change, so this solution isn't ideal. Please tell me if this approach is OK or if you'd prefer something else.

This adds a new `AcceptChildItem` property in `DropInfo` (specifically *not* in `IDropInfo` in order to avoid the breaking change), which will recalculate the relevant properties when set to `false` by the user.

Here's the result:

![files-example](https://user-images.githubusercontent.com/7913492/188285722-fb1e63fd-ba96-4f70-993c-b4e5341c6b5f.gif)

/cc @jizc 
