### PR TITLE
Touch and hold drag to support touch scrolling

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
@@ -1660,5 +1660,63 @@ namespace GongSolutions.Wpf.DragDrop
         {
             element.SetValue(DropTargetItemsSorterProperty, value);
         }
+
+        /// <summary>
+        /// Gets or sets the background brush for the touch hold adorner.
+        /// </summary>
+        public static readonly DependencyProperty TouchHoldAdornerBackgroundProperty
+            = DependencyProperty.RegisterAttached("TouchHoldAdornerBackground",
+                                                  typeof(Brush),
+                                                  typeof(DragDrop),
+                                                  new PropertyMetadata(Brushes.DeepSkyBlue));
+
+        /// <summary>Helper for getting <see cref="TouchHoldAdornerBackgroundProperty"/> from <paramref name="element"/>.</summary>
+        /// <param name="element"><see cref="DependencyObject"/> to read <see cref="TouchHoldAdornerBackgroundProperty"/> from.</param>
+        /// <remarks>Gets the background brush for the touch hold adorner.</remarks>
+        /// <returns>TouchHoldAdornerBackground property value.</returns>
+        [AttachedPropertyBrowsableForType(typeof(UIElement))]
+        public static Brush GetTouchHoldAdornerBackground(DependencyObject element)
+        {
+            return (Brush)element.GetValue(TouchHoldAdornerBackgroundProperty);
+        }
+
+        /// <summary>Helper for setting <see cref="TouchHoldAdornerBackgroundProperty"/> on <paramref name="element"/>.</summary>
+        /// <param name="element"><see cref="DependencyObject"/> to set <see cref="TouchHoldAdornerBackgroundProperty"/> on.</param>
+        /// <param name="value">TouchHoldAdornerBackground property value.</param>
+        /// <remarks>Sets the background brush for the touch hold adorner.</remarks>
+        [AttachedPropertyBrowsableForType(typeof(UIElement))]
+        public static void SetTouchHoldAdornerBackground(DependencyObject element, Brush value)
+        {
+            element.SetValue(TouchHoldAdornerBackgroundProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the delay in milliseconds before a touch and hold gesture triggers a drag.
+        /// </summary>
+        public static readonly DependencyProperty TouchHoldDelayProperty
+            = DependencyProperty.RegisterAttached("TouchHoldDelay",
+                                                  typeof(int),
+                                                  typeof(DragDrop),
+                                                  new PropertyMetadata(600));
+
+        /// <summary>Helper for getting <see cref="TouchHoldDelayProperty"/> from <paramref name="element"/>.</summary>
+        /// <param name="element"><see cref="DependencyObject"/> to read <see cref="TouchHoldDelayProperty"/> from.</param>
+        /// <remarks>Gets the delay in milliseconds before a touch and hold gesture triggers a drag.</remarks>
+        /// <returns>TouchHoldDelay property value.</returns>
+        [AttachedPropertyBrowsableForType(typeof(UIElement))]
+        public static int GetTouchHoldDelay(DependencyObject element)
+        {
+            return (int)element.GetValue(TouchHoldDelayProperty);
+        }
+
+        /// <summary>Helper for setting <see cref="TouchHoldDelayProperty"/> on <paramref name="element"/>.</summary>
+        /// <param name="element"><see cref="DependencyObject"/> to set <see cref="TouchHoldDelayProperty"/> on.</param>
+        /// <param name="value">TouchHoldDelay property value.</param>
+        /// <remarks>Sets the delay in milliseconds before a touch and hold gesture triggers a drag.</remarks>
+        [AttachedPropertyBrowsableForType(typeof(UIElement))]
+        public static void SetTouchHoldDelay(DependencyObject element, int value)
+        {
+            element.SetValue(TouchHoldDelayProperty, value);
+        }
     }
 }

--- a/src/GongSolutions.WPF.DragDrop/TouchAdorner.cs
+++ b/src/GongSolutions.WPF.DragDrop/TouchAdorner.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Diagnostics;
+using System.Windows;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
+using System.Windows.Shapes;
+
+namespace GongSolutions.Wpf.DragDrop
+{
+    public class TouchAdorner : Adorner
+    {
+        private readonly TouchPoint touchPoint;
+        private readonly Brush background;
+        private Ellipse ellipse;
+        private readonly VisualCollection visualChildren;
+
+        public TouchAdorner(UIElement adornedElement, TouchPoint touchPoint, Brush background) : base(adornedElement)
+        {
+            this.touchPoint = touchPoint;
+            this.background = background;
+            visualChildren = new VisualCollection(this);
+            CreateChildren();
+        }
+
+        private void CreateChildren()
+        {
+            ellipse = new Ellipse
+            {
+                Fill = background,
+                IsHitTestVisible = false,
+                Opacity = 1.0,
+                Width = 90,
+                Height = 90
+            };
+
+            ellipse.Loaded += OnEllipseLoaded;
+
+            visualChildren.Add(ellipse);
+        }
+
+        private void OnEllipseLoaded(object sender, RoutedEventArgs e)
+        {
+            StartAnimation();
+        }
+
+        private void StartAnimation()
+        {
+            var sb = new Storyboard();
+
+            var st = new ScaleTransform();
+            ellipse.RenderTransform = st;
+            ellipse.RenderTransformOrigin = new Point(0.5, 0.5);
+            
+            var dak = new DoubleAnimationUsingKeyFrames
+            {
+                BeginTime = TimeSpan.FromMilliseconds(0)
+            };
+            Storyboard.SetTargetProperty(dak, new PropertyPath("(UIElement.RenderTransform).(ScaleTransform.ScaleX)"));
+            Storyboard.SetTarget(dak, ellipse);
+            dak.KeyFrames.Add(new EasingDoubleKeyFrame(0.0, KeyTime.FromTimeSpan(TimeSpan.FromMilliseconds(0))));
+            dak.KeyFrames.Add(new EasingDoubleKeyFrame(1.0, KeyTime.FromTimeSpan(TimeSpan.FromMilliseconds(300)), new QuinticEase { EasingMode = EasingMode.EaseOut }));
+            sb.Children.Add(dak);
+
+            dak = new DoubleAnimationUsingKeyFrames
+            {
+                BeginTime = TimeSpan.FromMilliseconds(0)
+            };
+            Storyboard.SetTargetProperty(dak, new PropertyPath("(UIElement.RenderTransform).(ScaleTransform.ScaleY)"));
+            Storyboard.SetTarget(dak, ellipse);
+            dak.KeyFrames.Add(new EasingDoubleKeyFrame(0.0, KeyTime.FromTimeSpan(TimeSpan.FromMilliseconds(0))));
+            dak.KeyFrames.Add(new EasingDoubleKeyFrame(1.0, KeyTime.FromTimeSpan(TimeSpan.FromMilliseconds(300)), new QuinticEase { EasingMode = EasingMode.EaseOut }));
+            sb.Children.Add(dak);
+
+            dak = new DoubleAnimationUsingKeyFrames
+            {
+                BeginTime = TimeSpan.FromMilliseconds(300)
+            };
+            Storyboard.SetTargetProperty(dak, new PropertyPath("(UIElement.RenderTransform).(ScaleTransform.ScaleX)"));
+            Storyboard.SetTarget(dak, ellipse);
+            dak.KeyFrames.Add(new EasingDoubleKeyFrame(1.0, KeyTime.FromTimeSpan(TimeSpan.FromMilliseconds(0))));
+            dak.KeyFrames.Add(new EasingDoubleKeyFrame(0.0, KeyTime.FromTimeSpan(TimeSpan.FromMilliseconds(300)), new QuinticEase { EasingMode = EasingMode.EaseOut }));
+            sb.Children.Add(dak);
+
+            dak = new DoubleAnimationUsingKeyFrames
+            {
+                BeginTime = TimeSpan.FromMilliseconds(300)
+            };
+            Storyboard.SetTargetProperty(dak, new PropertyPath("(UIElement.RenderTransform).(ScaleTransform.ScaleY)"));
+            Storyboard.SetTarget(dak, ellipse);
+            dak.KeyFrames.Add(new EasingDoubleKeyFrame(1.0, KeyTime.FromTimeSpan(TimeSpan.FromMilliseconds(0))));
+            dak.KeyFrames.Add(new EasingDoubleKeyFrame(0.0, KeyTime.FromTimeSpan(TimeSpan.FromMilliseconds(300)), new QuinticEase { EasingMode = EasingMode.EaseOut }));
+            sb.Children.Add(dak);
+
+            sb.Begin();
+        }
+
+        protected override Size ArrangeOverride(Size finalSize)
+        {
+            var x = touchPoint.Position.X - ellipse.DesiredSize.Width / 2;
+            var y = touchPoint.Position.Y - ellipse.DesiredSize.Height / 2;
+
+            var rect = new Rect(x, y, ellipse.DesiredSize.Width, ellipse.DesiredSize.Height);
+
+            Debug.WriteLine($"Arrange: {rect.X},{rect.Y},{rect.Width},{rect.Height}");
+
+            ellipse.Arrange(rect);
+
+            return finalSize;
+        }
+
+        protected override int VisualChildrenCount => visualChildren.Count;
+        protected override Visual GetVisualChild(int index)
+        {
+            return visualChildren[index];
+        }
+    }
+}


### PR DESCRIPTION
## What changed?

This fixes #360.

_I am building a commercial app that is 100% touch, so this feature is critical for me. I hope it will help others. This is my first PR here, so I appreciate your patience and understanding._ 

To simultaneously support touch drag and scrolling in a scrollable ItemsControl, I updated DragDrop.cs with a touch and hold gesture that will trigger a drag operation after configurable number of milliseconds. 

When the user places their finger down, holds, and the timer ticks, it will display an animated adorner under their finger giving them a visual indicator that they can drag the item.

When the touch drag starts, the system sets the ScrollViewer.PanningMode="None" to prevent touch scrolling. The system will remember the previous setting and restore it once the drag is complete.

I added two attached properties to the DragDrop.Properties.cs file to support setting the background color of the touch and hold adorner as well as the touch and hold delay. The default delay is 600 milliseconds.
* TouchHoldAdornerBackground (Brush)
* TouchHoldDelay (int)

For the best touch user experience in a scrollable ItemsControl, the following properties should be set on the ItemsControl:
* ScrollViewer.PanningMode="Both" (this allows touch scrolling)
* Stylus.IsPressAndHoldEnabled="False"  (this turns off the context menu white box that appears)
