### PR TITLE
* Use MultiSelector's UnselectAll() method instead of iterating over …

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/Utilities/ItemsControlExtensions.cs
+++ b/src/GongSolutions.WPF.DragDrop/Utilities/ItemsControlExtensions.cs
@@ -317,13 +317,7 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
         {
             if (itemsControl is MultiSelector multiSelector)
             {
-                var itemsToDeselect = multiSelector.SelectedItems.Cast<object>().Where(si => si != item2Select).ToArray();
-
-                foreach (var item in itemsToDeselect)
-                {
-                    multiSelector.SelectedItems.Remove(item);
-                }
-
+                multiSelector.UnselectAll();
                 multiSelector.SetCurrentValue(Selector.SelectedItemProperty, item2Select);
 
                 if (itemsControl is DataGrid dataGrid)

--- a/src/Showcase/Models/SampleData.cs
+++ b/src/Showcase/Models/SampleData.cs
@@ -9,7 +9,7 @@ namespace Showcase.WPF.DragDrop.Models
     {
         public SampleData()
         {
-            for (var n = 0; n < 50; ++n)
+            for (var n = 0; n < 10_000; ++n)
             {
                 this.SerializableCollection1.Add(new SerializableItemModel(n + 1));
                 this.Collection1.Add(new ItemModel(n + 1));


### PR DESCRIPTION
…the collection with items to deselect; This increases the performance significant!

e.g. for a DataGrid with 5.000 rows from > 3s to < 20ms

## What changed?
Extension Method SetSelectedItem in ItemsControlExtensions.cs is adapted.
Instead collect items to deselect and iterating over this collection, use UnselectAll() method.

To demonstrate the difference the DataGrid Sample is modified too.

An issue wasn't open yet.
