### PR TITLE
Always correctly reset state when drag is cancelled

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.Properties.cs
@@ -100,7 +100,6 @@ namespace GongSolutions.Wpf.DragDrop
                 uiElement.PreviewTouchUp -= DragSourceOnTouchUp;
                 uiElement.PreviewTouchMove -= DragSourceOnTouchMove;
 
-                uiElement.QueryContinueDrag -= DragSourceOnQueryContinueDrag;
                 uiElement.GiveFeedback -= DragSourceOnGiveFeedback;
 
                 if ((bool)e.NewValue)
@@ -113,7 +112,6 @@ namespace GongSolutions.Wpf.DragDrop
                     uiElement.PreviewTouchUp += DragSourceOnTouchUp;
                     uiElement.PreviewTouchMove += DragSourceOnTouchMove;
 
-                    uiElement.QueryContinueDrag += DragSourceOnQueryContinueDrag;
                     uiElement.GiveFeedback += DragSourceOnGiveFeedback;
                 }
             }

--- a/src/GongSolutions.WPF.DragDrop/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.cs
@@ -655,6 +655,10 @@ namespace GongSolutions.Wpf.DragDrop
                                 if (dragDropEffects == DragDropEffects.None)
                                 {
                                     dragHandler.DragCancelled();
+                                    DragDropPreview = null;
+                                    DragDropEffectPreview = null;
+                                    DropTargetAdorner = null;
+                                    Mouse.OverrideCursor = null;
                                 }
 
                                 dragHandler.DragDropOperationFinished(dragDropEffects, dragInfo);
@@ -675,17 +679,6 @@ namespace GongSolutions.Wpf.DragDrop
                         }
                     }
                 }
-            }
-        }
-
-        private static void DragSourceOnQueryContinueDrag(object sender, QueryContinueDragEventArgs e)
-        {
-            if (e.Action == DragAction.Cancel || e.EscapePressed || (e.KeyStates.HasFlag(DragDropKeyStates.LeftMouseButton) == e.KeyStates.HasFlag(DragDropKeyStates.RightMouseButton)))
-            {
-                DragDropPreview = null;
-                DragDropEffectPreview = null;
-                DropTargetAdorner = null;
-                Mouse.OverrideCursor = null;
             }
         }
 


### PR DESCRIPTION
## What changed?

Move code for resetting of drag preview states into cancellation handling, so it is always executed.

Fixes #493 

