### PR TITLE
Check for IsHitTestVisible during hit tests

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/Utilities/HitTestUtilities.cs
+++ b/src/GongSolutions.WPF.DragDrop/Utilities/HitTestUtilities.cs
@@ -24,7 +24,34 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
                 return null;
             }
 
-            var hit = VisualTreeHelper.HitTest(visual, elementPosition);
+            HitTestResult hit = null;
+
+            VisualTreeHelper.HitTest(
+                visual,
+                potentialHitTestTarget =>
+                    {
+                        var isHitTestVisible = false;
+
+                        if (potentialHitTestTarget is UIElement uiElement)
+                        {
+                            isHitTestVisible = uiElement.IsHitTestVisible;
+                        }
+                        else if (potentialHitTestTarget is UIElement3D uiElement3D)
+                        {
+                            isHitTestVisible = uiElement3D.IsHitTestVisible;
+                        }
+
+                        return isHitTestVisible ? HitTestFilterBehavior.Continue : HitTestFilterBehavior.ContinueSkipSelf;
+                    },
+                result =>
+                    {
+                        hit = result;
+
+                        // Stop on first element found
+                        return HitTestResultBehavior.Stop;
+                    },
+                new PointHitTestParameters(elementPosition)
+            );
 
             return hit?.VisualHit.GetVisualAncestor<T>();
         }


### PR DESCRIPTION
## What changed?

During the hit tests checks, the IsHitTestVisible property is ignored, only IsVisible is checked later.

This can lead to issues when a TextBox is overlayed by a TextBlock with IsHitTestVisible=false (for example in a naming control with edit and readonly states). The HitTest will detect the TextBlock in the foreground, see IsVisible = false and return. The visible 
TextBox is completely ignored and the drag is executed anyway.

This PR should fix that issue.
