### PR TITLE
Threading Problem

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/DropTargetAdorner.cs
+++ b/src/GongSolutions.WPF.DragDrop/DropTargetAdorner.cs
@@ -27,6 +27,12 @@ namespace GongSolutions.Wpf.DragDrop
 
         public void Detatch()
         {
+            if (!m_AdornerLayer.Dispatcher.CheckAccess())
+            {
+                m_AdornerLayer.Dispatcher.Invoke(this.Detatch);
+                return;
+            }
+
             this.m_AdornerLayer.Remove(this);
         }
 


### PR DESCRIPTION
## What changed?

If you have multi-threaded windows, the detach call can cause an InvalidOperationException.
This change is checking for access, otherwise marshalling the call to the associated dispatcher of the AdornerLayer
