### PR TITLE
Catch and handle exceptions in dispatcher thread

### DIFF
--- a/src/GongSolutions.WPF.DragDrop/DragDrop.cs
+++ b/src/GongSolutions.WPF.DragDrop/DragDrop.cs
@@ -652,7 +652,7 @@ namespace GongSolutions.Wpf.DragDrop
                                     DragDropPreview?.Move(getPosition(DragDropPreview.PlacementTarget));
                                 }
 
-                                MouseHelper.HookMouseMove(point =>
+                                MouseHelper.HookMouseMove(dragHandler, point =>
                                     {
                                         if (DragDropPreview?.PlacementTarget != null)
                                         {

--- a/src/GongSolutions.WPF.DragDrop/Utilities/MouseHelper.cs
+++ b/src/GongSolutions.WPF.DragDrop/Utilities/MouseHelper.cs
@@ -9,14 +9,24 @@ namespace GongSolutions.Wpf.DragDrop.Utilities
     {
         private static System.Windows.Threading.DispatcherTimer _timer;
 
-        internal static void HookMouseMove(Action<System.Windows.Point> mouseMoveHandler)
+        internal static void HookMouseMove(IDragSource dragHandler, Action<System.Windows.Point> mouseMoveHandler)
         {
             _timer = new System.Windows.Threading.DispatcherTimer(System.Windows.Threading.DispatcherPriority.Input);
             _timer.Tick += (_, _) =>
                 {
-                    if (TryGetCursorPos(out var lpPoint))
+                    try
                     {
-                        mouseMoveHandler?.Invoke(new System.Windows.Point(lpPoint.x, lpPoint.y));
+                        if (TryGetCursorPos(out var lpPoint))
+                        {
+                            mouseMoveHandler?.Invoke(new System.Windows.Point(lpPoint.x, lpPoint.y));
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        if (!dragHandler.TryCatchOccurredException(ex))
+                        {
+                            throw;
+                        }
                     }
                 };
             _timer.Interval = new TimeSpan(1);


### PR DESCRIPTION
## What changed?

Added try/catch to ensure that Exceptions in the Dispatcher thread of the DispatcherTimer of MouseHelper are caught and handled.

Fixes issue #501.
